### PR TITLE
Add Feature: create initial snapshot of VM after clean-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.3 (unreleased)
+
+* New Feature: Create initial snapshot of VM after clean-up
+
 ## 0.0.1 (April 19, 2021)
 
 * VMware Plugin break out from Packer core. Changes prior to break out can be found in [Packer's CHANGELOG](https://github.com/hashicorp/packer/blob/master/CHANGELOG.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.3 (unreleased)
+## 0.0.2 (unreleased)
 
 * New Feature: Create initial snapshot of VM after clean-up
 

--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -31,6 +31,10 @@ type Driver interface {
 	// CreateDisk creates a virtual disk with the given size.
 	CreateDisk(string, string, string, string) error
 
+	// CreateSnapshot creates a snapshot of the supplied .vmx file with
+	// the given name
+	CreateSnapshot(string, string) error
+
 	// Checks if the VMX file at the given path is running.
 	IsRunning(string) (bool, error)
 

--- a/builder/vmware/common/driver_esx5.go
+++ b/builder/vmware/common/driver_esx5.go
@@ -180,6 +180,11 @@ func (d *ESX5Driver) CreateDisk(diskPathLocal string, size string, adapter_type 
 	return d.sh("vmkfstools", "-c", size, "-d", typeId, "-a", adapter_type, diskPath)
 }
 
+func (d *ESX5Driver) CreateSnapshot(vmxPath string, snapshotName string) error {
+	_, err := d.run(nil, "vim-cmd", "vmsvc/snapshot.create", d.vmId, snapshotName)
+	return err
+}
+
 func (d *ESX5Driver) IsRunning(string) (bool, error) {
 	state, err := d.run(nil, "vim-cmd", "vmsvc/power.getstate", d.vmId)
 	if err != nil {

--- a/builder/vmware/common/driver_fusion5.go
+++ b/builder/vmware/common/driver_fusion5.go
@@ -58,6 +58,12 @@ func (d *Fusion5Driver) CreateDisk(output string, size string, adapter_type stri
 	return nil
 }
 
+func (d *Fusion5Driver) CreateSnapshot(vmxPath string, snapshotName string) error {
+	cmd := exec.Command(d.vmrunPath(), "-T", "fusion", "snapshot", vmxPath, snapshotName)
+	_, _, err := runAndLog(cmd)
+	return err
+}
+
 func (d *Fusion5Driver) IsRunning(vmxPath string) (bool, error) {
 	vmxPath, err := filepath.Abs(vmxPath)
 	if err != nil {

--- a/builder/vmware/common/driver_mock.go
+++ b/builder/vmware/common/driver_mock.go
@@ -28,6 +28,11 @@ type DriverMock struct {
 	CreateDiskTypeId      string
 	CreateDiskErr         error
 
+	CreateSnapshotCalled  bool
+	CreateSnapshotVMXPath string
+	CreateSnapshotName    string
+	CreateSnapshotErr     error
+
 	ExportCalled bool
 	ExportArgs   []string
 
@@ -136,6 +141,13 @@ func (d *DriverMock) CreateDisk(output string, size string, adapterType string, 
 	d.CreateDiskAdapterType = adapterType
 	d.CreateDiskTypeId = typeId
 	return d.CreateDiskErr
+}
+
+func (d *DriverMock) CreateSnapshot(vmxPath string, snapshotName string) error {
+	d.CreateSnapshotCalled = true
+	d.CreateSnapshotVMXPath = vmxPath
+	d.CreateSnapshotName = snapshotName
+	return d.CreateSnapshotErr
 }
 
 func (d *DriverMock) IsRunning(path string) (bool, error) {

--- a/builder/vmware/common/driver_player5.go
+++ b/builder/vmware/common/driver_player5.go
@@ -84,6 +84,12 @@ func (d *Player5Driver) CreateDisk(output string, size string, adapter_type stri
 	return nil
 }
 
+func (d *Player5Driver) CreateSnapshot(vmxPath string, snapshotName string) error {
+	cmd := exec.Command(d.VmrunPath, "-T", "player", "snapshot", vmxPath, snapshotName)
+	_, _, err := runAndLog(cmd)
+	return err
+}
+
 func (d *Player5Driver) IsRunning(vmxPath string) (bool, error) {
 	vmxPath, err := filepath.Abs(vmxPath)
 	if err != nil {

--- a/builder/vmware/common/driver_workstation9.go
+++ b/builder/vmware/common/driver_workstation9.go
@@ -57,6 +57,12 @@ func (d *Workstation9Driver) CreateDisk(output string, size string, adapter_type
 	return nil
 }
 
+func (d *Workstation9Driver) CreateSnapshot(vmxPath string, snapshotName string) error {
+	cmd := exec.Command(d.VmrunPath, "-T", "ws", "snapshot", vmxPath, snapshotName)
+	_, _, err := runAndLog(cmd)
+	return err
+}
+
 func (d *Workstation9Driver) IsRunning(vmxPath string) (bool, error) {
 	vmxPath, err := filepath.Abs(vmxPath)
 	if err != nil {

--- a/builder/vmware/common/step_create_snapshot.go
+++ b/builder/vmware/common/step_create_snapshot.go
@@ -34,6 +34,9 @@ func (s *StepCreateSnapshot) Run(ctx context.Context, state multistep.StateBag) 
 			ui.Error(err.Error())
 			return multistep.ActionHalt
 		}
+		state.Put("snapshot_created", true)
+	} else {
+		state.Put("snapshot_skipped", true)
 	}
 	return multistep.ActionContinue
 }

--- a/builder/vmware/common/step_create_snapshot.go
+++ b/builder/vmware/common/step_create_snapshot.go
@@ -1,0 +1,41 @@
+package common
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+// This step creates the intial snapshot for the VM after clean-up.
+//
+// Uses:
+//   config *config
+//   driver Driver
+//   ui     packersdk.Ui
+//
+// Produces:
+//   snapshot
+type StepCreateSnapshot struct {
+	SnapshotName *string
+}
+
+func (s *StepCreateSnapshot) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	if *s.SnapshotName != "" { // if snapshot name is set create one, if not don't
+		driver := state.Get("driver").(Driver)
+		ui := state.Get("ui").(packersdk.Ui)
+
+		ui.Say("Creating inital snapshot")
+		vmFullPath := state.Get("vmx_path").(string)
+		if err := driver.CreateSnapshot(vmFullPath, *s.SnapshotName); err != nil {
+			err := fmt.Errorf("Error creating snapshot: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+	}
+	return multistep.ActionContinue
+}
+
+func (s *StepCreateSnapshot) Cleanup(multistep.StateBag) {}

--- a/builder/vmware/common/step_create_snapshot_test.go
+++ b/builder/vmware/common/step_create_snapshot_test.go
@@ -1,0 +1,39 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+)
+
+func TestStepCreateSnapshot_impl(t *testing.T) {
+	var _ multistep.Step = new(StepCreateSnapshot)
+}
+
+func NewTestCreateSnapshotStep() *StepCreateSnapshot {
+	return &StepCreateSnapshot{
+		SnapshotName: strPtr("snapshot_name"),
+	}
+}
+
+func TestStepCreateSnapshot(t *testing.T) {
+	state := testState(t)
+	step := NewTestCreateSnapshotStep()
+
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+
+	driver := state.Get("driver").(*DriverMock)
+	if !driver.CreateSnapshotCalled {
+		t.Fatalf("Should have called create snapshot.")
+	}
+	// TODO: proper testing
+
+	// Cleanup
+	step.Cleanup(state)
+}

--- a/builder/vmware/common/step_create_snapshot_test.go
+++ b/builder/vmware/common/step_create_snapshot_test.go
@@ -21,6 +21,8 @@ func TestStepCreateSnapshot(t *testing.T) {
 	state := testState(t)
 	step := NewTestCreateSnapshotStep()
 
+	state.Put("vmx_path", "foo")
+
 	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
 		t.Fatalf("bad action: %#v", action)
 	}
@@ -32,7 +34,37 @@ func TestStepCreateSnapshot(t *testing.T) {
 	if !driver.CreateSnapshotCalled {
 		t.Fatalf("Should have called create snapshot.")
 	}
-	// TODO: proper testing
+
+	if _, ok := state.GetOk("snapshot_skiped"); ok {
+		t.Fatalf("Should NOT skip snapshot creation")
+	}
+
+	if _, ok := state.GetOk("snapshot_created"); !ok {
+		t.Fatalf("Should create snapshot")
+	}
+
+	// Cleanup
+	step.Cleanup(state)
+}
+
+func TestStepCreateSnapshot_skip(t *testing.T) {
+	state := testState(t)
+	step := NewTestCreateSnapshotStep()
+	step.SnapshotName = strPtr("")
+
+	state.Put("vmx_path", "foo")
+
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+
+	driver := state.Get("driver").(*DriverMock)
+	if driver.CreateSnapshotCalled {
+		t.Fatalf("Should NOT have called create snapshot.")
+	}
 
 	// Cleanup
 	step.Cleanup(state)

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -178,6 +178,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			RemoveEthernetInterfaces: b.config.VMXConfig.VMXRemoveEthernet,
 			VNCEnabled:               !b.config.DisableVNC,
 		},
+		&vmwcommon.StepCreateSnapshot{
+			SnapshotName: &b.config.SnapshotName,
+		},
 		&vmwcommon.StepUploadVMX{
 			RemoteType: b.config.RemoteType,
 		},

--- a/builder/vmware/iso/config.go
+++ b/builder/vmware/iso/config.go
@@ -75,6 +75,9 @@ type Config struct {
 	// non-functional. See below for more information. For basic VMX
 	// modifications, try `vmx_data` first.
 	VMXTemplatePath string `mapstructure:"vmx_template_path" required:"false"`
+	// This is the name of the initial snapshot created after provisioning and cleanup.
+	// if left blank, no initial snapshot will be created
+	SnapshotName string `mapstructure:"snapshot_name" required:"false"`
 
 	ctx interpolate.Context
 }

--- a/builder/vmware/iso/config.hcl2spec.go
+++ b/builder/vmware/iso/config.hcl2spec.go
@@ -145,6 +145,7 @@ type FlatConfig struct {
 	VMName                    *string           `mapstructure:"vm_name" required:"false" cty:"vm_name" hcl:"vm_name"`
 	VMXDiskTemplatePath       *string           `mapstructure:"vmx_disk_template_path" cty:"vmx_disk_template_path" hcl:"vmx_disk_template_path"`
 	VMXTemplatePath           *string           `mapstructure:"vmx_template_path" required:"false" cty:"vmx_template_path" hcl:"vmx_template_path"`
+	SnapshotName              *string           `mapstructure:"snapshot_name" required:"false" cty:"snapshot_name" hcl:"snapshot_name"`
 }
 
 // FlatMapstructure returns a new FlatConfig.

--- a/builder/vmware/iso/config.hcl2spec.go
+++ b/builder/vmware/iso/config.hcl2spec.go
@@ -294,6 +294,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vm_name":                        &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"vmx_disk_template_path":         &hcldec.AttrSpec{Name: "vmx_disk_template_path", Type: cty.String, Required: false},
 		"vmx_template_path":              &hcldec.AttrSpec{Name: "vmx_template_path", Type: cty.String, Required: false},
+		"snapshot_name":                  &hcldec.AttrSpec{Name: "snapshot_name", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -172,6 +172,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			RemoveEthernetInterfaces: b.config.VMXConfig.VMXRemoveEthernet,
 			VNCEnabled:               !b.config.DisableVNC,
 		},
+		&vmwcommon.StepCreateSnapshot{
+			SnapshotName: &b.config.SnapshotName,
+		},
 		&vmwcommon.StepUploadVMX{
 			RemoteType: b.config.RemoteType,
 		},

--- a/builder/vmware/vmx/config.go
+++ b/builder/vmware/vmx/config.go
@@ -59,6 +59,9 @@ type Config struct {
 	// machine, without the file extension. By default this is packer-BUILDNAME,
 	// where "BUILDNAME" is the name of the build.
 	VMName string `mapstructure:"vm_name" required:"false"`
+	// This is the name of the initial snapshot created after provisioning and cleanup.
+	// if left blank, no initial snapshot will be created
+	SnapshotName string `mapstructure:"snapshot_name" required:"false"`
 
 	ctx interpolate.Context
 }

--- a/builder/vmware/vmx/config.hcl2spec.go
+++ b/builder/vmware/vmx/config.hcl2spec.go
@@ -127,6 +127,7 @@ type FlatConfig struct {
 	AttachSnapshot            *string           `mapstructure:"attach_snapshot" required:"false" cty:"attach_snapshot" hcl:"attach_snapshot"`
 	SourcePath                *string           `mapstructure:"source_path" required:"true" cty:"source_path" hcl:"source_path"`
 	VMName                    *string           `mapstructure:"vm_name" required:"false" cty:"vm_name" hcl:"vm_name"`
+	SnapshotName              *string           `mapstructure:"snapshot_name" required:"false" cty:"snapshot_name" hcl:"snapshot_name"`
 }
 
 // FlatMapstructure returns a new FlatConfig.

--- a/builder/vmware/vmx/config.hcl2spec.go
+++ b/builder/vmware/vmx/config.hcl2spec.go
@@ -258,6 +258,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"attach_snapshot":                &hcldec.AttrSpec{Name: "attach_snapshot", Type: cty.String, Required: false},
 		"source_path":                    &hcldec.AttrSpec{Name: "source_path", Type: cty.String, Required: false},
 		"vm_name":                        &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
+		"snapshot_name":                  &hcldec.AttrSpec{Name: "snapshot_name", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/docs-partials/builder/vmware/iso/Config-not-required.mdx
+++ b/docs-partials/builder/vmware/iso/Config-not-required.mdx
@@ -39,4 +39,7 @@
   non-functional. See below for more information. For basic VMX
   modifications, try `vmx_data` first.
 
+- `snapshot_name` (string) - This is the name of the initial snapshot created after provisioning and cleanup.
+  if left blank, no initial snapshot will be created
+
 <!-- End of code generated from the comments of the Config struct in builder/vmware/iso/config.go; -->

--- a/docs-partials/builder/vmware/vmx/Config-not-required.mdx
+++ b/docs-partials/builder/vmware/vmx/Config-not-required.mdx
@@ -23,4 +23,7 @@
   machine, without the file extension. By default this is packer-BUILDNAME,
   where "BUILDNAME" is the name of the build.
 
+- `snapshot_name` (string) - This is the name of the initial snapshot created after provisioning and cleanup.
+  if left blank, no initial snapshot will be created
+
 <!-- End of code generated from the comments of the Config struct in builder/vmware/vmx/config.go; -->

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "0.0.3"
+	Version = "0.0.2"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "0.0.2"
+	Version = "0.0.3"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
* extended drivers by `CreateSnapshot` method to create snapshots
* added additional step to builders to create initial snapshot of the finished VM (after clean-up)

simply set the `"snapshot_name"` field inside the builder's config to create an initial snapshot (if not set, snapshot creation will be skipped)

Closes #20 
