### PR TITLE
Fix cd_content is ignored

### DIFF
--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -77,8 +77,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Label:       b.config.FloppyConfig.FloppyLabel,
 		},
 		&commonsteps.StepCreateCD{
-			Files: b.config.CDConfig.CDFiles,
-			Label: b.config.CDConfig.CDLabel,
+			Files:   b.config.CDConfig.CDFiles,
+			Content: b.config.CDConfig.CDContent,
+			Label:   b.config.CDConfig.CDLabel,
 		},
 		&vmwcommon.StepRemoteUpload{
 			Key:       "floppy_path",

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -74,8 +74,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Label:       b.config.FloppyConfig.FloppyLabel,
 		},
 		&commonsteps.StepCreateCD{
-			Files: b.config.CDConfig.CDFiles,
-			Label: b.config.CDConfig.CDLabel,
+			Files:   b.config.CDConfig.CDFiles,
+			Content: b.config.CDConfig.CDContent,
+			Label:   b.config.CDConfig.CDLabel,
 		},
 		&vmwcommon.StepRemoteUpload{
 			Key:       "floppy_path",

--- a/builder/vmware/vmx/builder_test.go
+++ b/builder/vmware/vmx/builder_test.go
@@ -66,3 +66,21 @@ func TestBuilderPrepare_InvalidFloppies(t *testing.T) {
 		t.Fatalf("Multierror should work and report 2 errors")
 	}
 }
+
+func TestBuilderPrepare_CDContent(t *testing.T) {
+	var b Builder
+	config := testConfig(t)
+	config["cd_content"] = map[string]string{
+		"something.txt": "foo!",
+	}
+	b = Builder{}
+	_, _, errs := b.Prepare(config)
+	if errs != nil {
+		t.Fatalf("using cd_content should just work")
+	}
+
+	if len(b.config.CDConfig.CDContent) == 0 {
+		t.Fatalf("cd_content is empty")
+	}
+
+}


### PR DESCRIPTION
This implements support for cd_content
(https://www.packer.io/docs/builders/vmware/vmx#cd_content)
by adding an omitted struct member. Closes #29