### PR TITLE
Fix handling of temporary cdrom devices

### DIFF
--- a/builder/vmware/common/step_configure_vmx.go
+++ b/builder/vmware/common/step_configure_vmx.go
@@ -22,7 +22,7 @@ import (
 type StepConfigureVMX struct {
 	CustomData       map[string]string
 	DisplayName      string
-	SkipFloppy       bool
+	SkipDevices      bool
 	VMName           string
 	DiskAdapterType  string
 	CDROMAdapterType string
@@ -65,9 +65,10 @@ func (s *StepConfigureVMX) Run(ctx context.Context, state multistep.StateBag) mu
 		vmxData[k] = v
 	}
 
-	// Set a floppy disk, but only if we should
-	if !s.SkipFloppy {
-		// Grab list of temporary builder devices so we can append the floppy to it
+	// StepConfigureVMX runs both before and after provisioning (for VmxDataPost),
+	// the latter time shouldn't create temporary devices
+	if !s.SkipDevices {
+		// Grab list of temporary builder devices so we can append to it
 		tmpBuildDevices := state.Get("temporaryDevices").([]string)
 
 		// Set a floppy disk if we have one
@@ -81,24 +82,18 @@ func (s *StepConfigureVMX) Run(ctx context.Context, state multistep.StateBag) mu
 			tmpBuildDevices = append(tmpBuildDevices, "floppy0")
 		}
 
-		// Build the list back in our statebag
-		state.Put("temporaryDevices", tmpBuildDevices)
-	}
+		// Add our custom CD, if it exists
+		if cdPath, ok := state.GetOk("cd_path"); ok {
+			if cdPath != "" {
+				diskAndCDConfigData := DefaultDiskAndCDROMTypes(s.DiskAdapterType, s.CDROMAdapterType)
+				cdromPrefix := diskAndCDConfigData.CDROMType + "1:" + diskAndCDConfigData.CDROMType_PrimarySecondary
+				vmxData[cdromPrefix+".present"] = "TRUE"
+				vmxData[cdromPrefix+".filename"] = cdPath.(string)
+				vmxData[cdromPrefix+".devicetype"] = "cdrom-image"
 
-	// Add our custom CD, if it exists
-	if cdPath, ok := state.GetOk("cd_path"); ok {
-		// Grab list of temporary builder devices so we can append the cd to it
-		tmpBuildDevices := state.Get("temporaryDevices").([]string)
-
-		if cdPath != "" {
-			diskAndCDConfigData := DefaultDiskAndCDROMTypes(s.DiskAdapterType, s.CDROMAdapterType)
-			cdromPrefix := diskAndCDConfigData.CDROMType + "1:" + diskAndCDConfigData.CDROMType_PrimarySecondary
-			vmxData[cdromPrefix+".present"] = "TRUE"
-			vmxData[cdromPrefix+".filename"] = cdPath.(string)
-			vmxData[cdromPrefix+".devicetype"] = "cdrom-image"
-
-			// Add it to our list of build devices to later remove
-			tmpBuildDevices = append(tmpBuildDevices, cdromPrefix)
+				// Add it to our list of build devices to later remove
+				tmpBuildDevices = append(tmpBuildDevices, cdromPrefix)
+			}
 		}
 
 		// Build the list back in our statebag

--- a/builder/vmware/common/step_configure_vmx.go
+++ b/builder/vmware/common/step_configure_vmx.go
@@ -94,8 +94,8 @@ func (s *StepConfigureVMX) Run(ctx context.Context, state multistep.StateBag) mu
 			diskAndCDConfigData := DefaultDiskAndCDROMTypes(s.DiskAdapterType, s.CDROMAdapterType)
 			cdromPrefix := diskAndCDConfigData.CDROMType + "1:" + diskAndCDConfigData.CDROMType_PrimarySecondary
 			vmxData[cdromPrefix+".present"] = "TRUE"
-			vmxData[cdromPrefix+".fileName"] = cdPath.(string)
-			vmxData[cdromPrefix+".deviceType"] = "cdrom-image"
+			vmxData[cdromPrefix+".filename"] = cdPath.(string)
+			vmxData[cdromPrefix+".devicetype"] = "cdrom-image"
 
 			// Add it to our list of build devices to later remove
 			tmpBuildDevices = append(tmpBuildDevices, cdromPrefix)

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -171,7 +171,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 		&vmwcommon.StepConfigureVMX{
 			CustomData:  b.config.VMXDataPost,
-			SkipFloppy:  true,
+			SkipDevices: true,
 			VMName:      b.config.VMName,
 			DisplayName: b.config.VMXDisplayName,
 		},

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -170,13 +170,6 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 
 	templateData.DiskAndCDConfigData = vmwcommon.DefaultDiskAndCDROMTypes(config.DiskAdapterType, config.CdromAdapterType)
 
-	/// Now that we figured out the CDROM device to add, store it
-	/// to the list of temporary build devices in our statebag
-	tmpBuildDevices := state.Get("temporaryDevices").([]string)
-	tmpCdromDevice := fmt.Sprintf("%s0:%s", templateData.CDROMType, templateData.CDROMType_PrimarySecondary)
-	tmpBuildDevices = append(tmpBuildDevices, tmpCdromDevice)
-	state.Put("temporaryDevices", tmpBuildDevices)
-
 	/// Assign the network adapter type into the template if one was specified.
 	network_adapter := strings.ToLower(config.HWConfig.NetworkAdapterType)
 	if network_adapter != "" {

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -165,7 +165,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 		&vmwcommon.StepConfigureVMX{
 			CustomData:  b.config.VMXDataPost,
-			SkipFloppy:  true,
+			SkipDevices: true,
 			VMName:      b.config.VMName,
 			DisplayName: b.config.VMXDisplayName,
 		},


### PR DESCRIPTION
Fix two more issues with vmware and cd_{files,content}

1. if a temporary cdPath is set up, during step_configure_vmx, it should be claned up by step_clean_vmx
   There is already [code to do this cleanup](https://github.com/hashicorp/packer-plugin-vmware/blob/e38fb9222041ec935202efd952836aa87fc6d1cb/builder/vmware/common/step_clean_vmx.go#L62-L70), but it wasn't triggering because it was only applied to vmware-iso (and had the wrong device name there). Only floppies were added to temporaryDevices when the setup was actually being done.

2. Fix updating/overwriting existing cdrom device properties (case-sensitivity)
   packer lowercases all the vmx keys when reading a file in: https://github.com/hashicorp/packer-plugin-vmware/blob/e38fb9222041ec935202efd952836aa87fc6d1cb/builder/vmware/common/vmx.go#L28

   so using mixed-case keys to update the .vmx introduces semantic duplicates (rather than replacing old values)
   https://github.com/hashicorp/packer-plugin-vmware/blob/e38fb9222041ec935202efd952836aa87fc6d1cb/builder/vmware/common/step_configure_vmx.go#L94-L95