### PR TITLE
Restore cleanup of temporary vmware-iso device for `iso_path`

### DIFF
--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -170,6 +170,13 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 
 	templateData.DiskAndCDConfigData = vmwcommon.DefaultDiskAndCDROMTypes(config.DiskAdapterType, config.CdromAdapterType)
 
+	/// Now that we figured out the CDROM device to add, store it
+	/// to the list of temporary build devices in our statebag
+	tmpBuildDevices := state.Get("temporaryDevices").([]string)
+	tmpCdromDevice := fmt.Sprintf("%s0:%s", templateData.CDROMType, templateData.CDROMType_PrimarySecondary)
+	tmpBuildDevices = append(tmpBuildDevices, tmpCdromDevice)
+	state.Put("temporaryDevices", tmpBuildDevices)
+
 	/// Assign the network adapter type into the template if one was specified.
 	network_adapter := strings.ToLower(config.HWConfig.NetworkAdapterType)
 	if network_adapter != "" {


### PR DESCRIPTION
This partially reverts commit 048e31aeb6d810f2683dd6a17ab867c3508a8982, fixing a regression caused by #31.

This code was not a mistaken attempt to clean up the device created
for `cd_{files,content}`, as I thought. It was cleaning up the device
(specific to  vmware-iso) on which the `{{ .ISOPath }}` is mounted.


See discussion at https://github.com/hashicorp/packer-plugin-vmware/issues/33#issuecomment-927120617, though this fix doesn't related directly to the original topic of that issue.

