### PR TITLE
fix: VMware Workstation installed to non-default path

### DIFF
--- a/builder/vmware/common/driver_workstation10.go
+++ b/builder/vmware/common/driver_workstation10.go
@@ -47,7 +47,7 @@ func (d *Workstation10Driver) Verify() error {
 		return err
 	}
 
-	return workstationVerifyVersion(VMWARE_WS_VERSION)
+	return workstationVerifyVersion(d.AppPath, VMWARE_WS_VERSION)
 }
 
 func (d *Workstation10Driver) GetVmwareDriver() VmwareDriver {

--- a/builder/vmware/common/driver_workstation10_windows.go
+++ b/builder/vmware/common/driver_workstation10_windows.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 )
 
-func workstationVerifyVersion(version string) error {
+func workstationVerifyVersion(_, version string) error {
 	key := `SOFTWARE\Wow6432Node\VMware, Inc.\VMware Workstation`
 	subkey := "ProductVersion"
 	productVersion, err := readRegString(syscall.HKEY_LOCAL_MACHINE, key, subkey)

--- a/builder/vmware/common/driver_workstation9.go
+++ b/builder/vmware/common/driver_workstation9.go
@@ -202,7 +202,7 @@ func (d *Workstation9Driver) Verify() error {
 }
 
 func (d *Workstation9Driver) ToolsIsoPath(flavor string) string {
-	return workstationToolsIsoPath(flavor)
+	return workstationToolsIsoPath(d.AppPath, flavor)
 }
 
 func (d *Workstation9Driver) ToolsInstall() error {

--- a/builder/vmware/common/driver_workstation9_windows.go
+++ b/builder/vmware/common/driver_workstation9_windows.go
@@ -45,7 +45,7 @@ func workstationFindVmrun() (string, error) {
 	return findFile("vmrun.exe", workstationProgramFilePaths()), nil
 }
 
-func workstationToolsIsoPath(flavor string) string {
+func workstationToolsIsoPath(_, flavor string) string {
 	return findFile(flavor+".iso", workstationProgramFilePaths())
 }
 

--- a/builder/vmware/common/driver_workstation_unix.go
+++ b/builder/vmware/common/driver_workstation_unix.go
@@ -116,26 +116,23 @@ func workstationNetmapConfPath() string {
 	return filepath.Join(base, "netmap.conf")
 }
 
-func workstationToolsIsoPath(flavor string) string {
-	return "/usr/lib/vmware/isoimages/" + flavor + ".iso"
+func workstationToolsIsoPath(appPath, flavor string) string {
+	libPath := filepath.Dir(filepath.Dir(appPath))
+	return filepath.Join(libPath, "vmware/isoimages/"+flavor+".iso")
 }
 
-func workstationVerifyVersion(version string) error {
+func workstationVerifyVersion(appPath, version string) error {
 	if runtime.GOOS != "linux" {
 		return fmt.Errorf("The VMware WS version %s driver is only supported on Linux, and Windows, at the moment. Your OS: %s", version, runtime.GOOS)
 	}
 
-	//TODO(pmyjavec) there is a better way to find this, how?
-	//the default will suffice for now.
-	vmxpath := "/usr/lib/vmware/bin/vmware-vmx"
-
-	var stderr bytes.Buffer
-	cmd := exec.Command(vmxpath, "-v")
-	cmd.Stderr = &stderr
+	var stdout bytes.Buffer
+	cmd := exec.Command(appPath, "-v")
+	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
 		return err
 	}
-	return workstationTestVersion(version, stderr.String())
+	return workstationTestVersion(version, stdout.String())
 }
 
 func workstationTestVersion(wanted, versionOutput string) error {

--- a/builder/vmware/common/driver_workstation_unix.go
+++ b/builder/vmware/common/driver_workstation_unix.go
@@ -117,6 +117,8 @@ func workstationNetmapConfPath() string {
 }
 
 func workstationToolsIsoPath(appPath, flavor string) string {
+	// appPath is full path to main vmware executable
+	// used to find where the application is installed
 	libPath := filepath.Dir(filepath.Dir(appPath))
 	return filepath.Join(libPath, "vmware/isoimages/"+flavor+".iso")
 }

--- a/builder/vmware/common/driver_workstation_unix.go
+++ b/builder/vmware/common/driver_workstation_unix.go
@@ -119,7 +119,7 @@ func workstationNetmapConfPath() string {
 func workstationToolsIsoPath(appPath, flavor string) string {
 	// appPath is full path to main vmware executable
 	// used to find where the application is installed
-	libPath := filepath.Dir(filepath.Dir(appPath))
+	libPath := filepath.Join(filepath.Dir(filepath.Dir(appPath)), "lib")
 	return filepath.Join(libPath, "vmware/isoimages/"+flavor+".iso")
 }
 


### PR DESCRIPTION
Non-default directory (like `/usr/local`) will not work for packer properly due to the absolute paths are used in version detection. This change should fix this issue and allow the packer users to use any path for distributive they want.

As a workaround for current packer 1.8.1 - create this script to fix an issue until the patch will be applied and new packer version issued:
* `/usr/lib/vmware/bin/vmware-vmx` (executable):
   ```sh
   #!/bin/sh
   vmware -v 1>&2
   ```
