### PR TITLE
Ensure the contents of `floppy_content` gets added to the configured floppy device

### DIFF
--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -74,6 +74,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		&commonsteps.StepCreateFloppy{
 			Files:       b.config.FloppyConfig.FloppyFiles,
 			Directories: b.config.FloppyConfig.FloppyDirectories,
+			Content:     b.config.FloppyConfig.FloppyContent,
 			Label:       b.config.FloppyConfig.FloppyLabel,
 		},
 		&commonsteps.StepCreateCD{

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -71,6 +71,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		&commonsteps.StepCreateFloppy{
 			Files:       b.config.FloppyConfig.FloppyFiles,
 			Directories: b.config.FloppyConfig.FloppyDirectories,
+			Content:     b.config.FloppyConfig.FloppyContent,
 			Label:       b.config.FloppyConfig.FloppyLabel,
 		},
 		&commonsteps.StepCreateCD{


### PR DESCRIPTION
Add `Content` to `StepCreateFloppy` to allow content to be added to floppy device.

Closes #77

