### PR TITLE
docs: update `README.md` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,60 @@
-# Packer Plugin Vmware
-The `Vmware` multi-component plugin can be used with HashiCorp [Packer](https://www.packer.io)
-to create custom images. For the full list of available features for this plugin see [docs](docs).
+# Packer Plugin for VMware
+
+The Packer Plugin for VMware is a multi-component plugin can be used with
+[Packer][packer] to create virtual machine images for use with VMware products.
+
+The plugin includes two builders which are able to create images, depending on
+your desired strategy:
+
+- [`vmware-iso`][docs-vmware-iso] - This builder creates a virtual machine,
+  installs an operating system from an ISO, provisions software within the
+  operating system, and then exports the virtual machine as an image. This
+  is best for those who want to start by creating a base image.
+
+- [`vmware-vmx`][docs-vmware-vmx] - This builder imports an existing virtual
+  machine (from a`.vmx` file), runs provisioners on the virtual machine, and
+  then exports the virtual machine as an image. This is best for those who want
+  to start from an existing virtual machine as the source. You can feed the
+  artifact of this builder back into Packer to iterate on a machine image.
+
+## Requirements
+
+**Desktop Hypervisor**:
+
+- VMware Fusion Pro (macOS)
+- VMware Workstation Pro (Linux and Windows)
+- VMware Workstation Player (Linux)
+
+**Bare Metal Hypervisor**:
+
+- VMware vSphere Hypervisor
+
+The plugin supports versions in accordance with the VMware Product Lifecycle
+Matrix from General Availability to End of General Support. Learn more:
+[VMware Product Lifecycle Matrix][vmware-product-lifecycle-matrix]
+
+**Go**:
+
+- [Go 1.17][golang-install]
+
+    Required if building the plugin.
 
 ## Installation
 
-### Using pre-built releases
+### Using Pre-built Releases
 
-#### Using the `packer init` command
+#### Automatic Installation
 
-Starting from version 1.7, Packer supports a new `packer init` command allowing
-automatic installation of Packer plugins. Read the
-[Packer documentation](https://www.packer.io/docs/commands/init) for more information.
+Packer v1.7.0 and later supports the `packer init` command which enables the
+automatic installation of Packer plugins. For more information, see the
+[Packer documentation][docs-packer-init].
 
-To install this plugin, copy and paste this code into your Packer configuration .
-Then, run [`packer init`](https://www.packer.io/docs/commands/init).
+To install this plugin, copy and paste this code (HCL2) into your Packer
+configuration and run `packer init`.
 
 ```hcl
 packer {
+  required_version = ">= 1.7.0"
   required_plugins {
     vmware = {
       version = ">= 1.0.0"
@@ -26,38 +64,51 @@ packer {
 }
 ```
 
+#### Manual Installation
 
-#### Manual installation
+You can download [pre-built binary releases][releases-vmware-plugin] of the
+plugin on GitHub. Once you have downloaded the latest release archive for your
+target operating system and architecture, uncompress to retrieve the plugin
+binary file for your platform.
 
-You can find pre-built binary releases of the plugin [here](https://github.com/hashicorp/packer-plugin-vmware/releases).
-Once you have downloaded the latest archive corresponding to your target OS,
-uncompress it to retrieve the plugin binary file corresponding to your platform.
-To install the plugin, please follow the Packer documentation on
-[installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
+To install the downloaded plugin, please follow the Packer documentation on
+[installing a plugin][docs-packer-plugin-install].
 
-
-### From Sources
+### Using the Source
 
 If you prefer to build the plugin from sources, clone the GitHub repository
-locally and run the command `go build` from the root
-directory. Upon successful compilation, a `packer-plugin-vmware` plugin
-binary file can be found in the root directory.
-To install the compiled plugin, please follow the official Packer documentation
-on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
+locally and run the command `go build` from the repository root directory.
+Upon successful compilation, a `packer-plugin-vmware` plugin binary file can be
+found in the root directory.
 
+To install the compiled plugin, please follow the Packer documentation on
+[installing a plugin][docs-packer-plugin-install].
 
 ### Configuration
 
-For more information on how to configure the plugin, please read the
-documentation located in the [`docs/`](docs) directory.
+For more information on how to configure the plugin, please see the plugin
+documentation.
 
+- `vmware-iso` [builder documentation][docs-vmware-iso]
+- `vmware-vmx` [builder documentation][docs-vmware-vmx]
 
 ## Contributing
 
-* If you think you've found a bug in the code or you have a question regarding
-  the usage of this software, please reach out to us by opening an issue in
-  this GitHub repository.
-* Contributions to this project are welcome: if you want to add a feature or a
-  fix a bug, please do so by opening a Pull Request in this GitHub repository.
-  In case of feature contribution, we kindly ask you to open an issue to
-  discuss it beforehand.
+- If you think you've found a bug in the code or you have a question regarding
+the usage of this software, please reach out to us by opening an issue in this
+GitHub repository.
+
+- Contributions to this project are welcome: if you want to add a feature or a
+fix a bug, please do so by opening a pull request in this GitHub repository.
+In case of feature contribution, we kindly ask you to open an issue to discuss
+it beforehand.
+
+[docs-packer-init]: https://www.packer.io/docs/commands/init
+[docs-packer-plugin-install]: https://www.packer.io/docs/extending/plugins/#installing-plugins
+[docs-vmware-iso]: https://www.packer.io/plugins/builders/vmware/iso
+[docs-vmware-vmx]: https://www.packer.io/plugins/builders/vmware/vmx
+[docs-vmware-plugin]: https://www.packer.io/docs/builders/vmware
+[golang-install]: https://golang.org/doc/install
+[packer]: https://www.packer.io
+[releases-vmware-plugin]: https://github.com/hashicorp/packer-plugin-vmware/releases
+[vmware-product-lifecycle-matrix]: https://lifecycle.vmware.com

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Packer Plugin for VMware
 
-The Packer Plugin for VMware is a multi-component plugin can be used with
+The Packer Plugin for VMware is a multi-component plugin that can be used with
 [Packer][packer] to create virtual machine images for use with VMware products.
 
 The plugin includes two builders which are able to create images, depending on

--- a/README.md
+++ b/README.md
@@ -66,13 +66,24 @@ packer {
 
 #### Manual Installation
 
-You can download [pre-built binary releases][releases-vmware-plugin] of the
-plugin on GitHub. Once you have downloaded the latest release archive for your
-target operating system and architecture, uncompress to retrieve the plugin
-binary file for your platform.
+Packer v1.8.0 and later supports the `packer plugins` command which enables the
+management of external plugins required by a configuration.
 
-To install the downloaded plugin, please follow the Packer documentation on
-[installing a plugin][docs-packer-plugin-install].
+For example, to download and install the latest available version of this plugin,
+run the following:
+
+```console
+packer plugins install github.com/hashicorp/vmware
+```
+
+For environments where the Packer host can not communicate with GitHub
+(_e.g._, a dark-site), you can download [pre-built binary releases][releases-vmware-plugin]
+of the plugin from GitHub. Once you have downloaded the latest release archive
+for your target operating system and architecture, uncompress to retrieve the
+plugin binary file for your platform.
+
+To transfer and install the downloaded plugin, please follow the Packer
+documentation on [installing a plugin][docs-packer-plugin-install].
 
 ### Using the Source
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,62 +1,19 @@
-# VMware Plugin
+# Plugin Components
 
-## Installation
+The Packer Plugin for VMware is a multi-component plugin can be used with
+Packer to create virtual machine images for use with VMware products.
 
-### Using pre-built releases
+The plugin includes two builders which are able to create images, depending on
+your desired strategy:
 
-#### Using the `packer init` command
+## Builders
 
-Starting from version 1.7, Packer supports a new `packer init` command allowing
-automatic installation of Packer plugins. Read the
-[Packer documentation](https://www.packer.io/docs/commands/init) for more information.
-
-To install this plugin, copy and paste this code into your Packer configuration .
-Then, run [`packer init`](https://www.packer.io/docs/commands/init).
-
-```hcl
-packer {
-  required_plugins {
-    vmware = {
-      version = ">= 1.0.0"
-      source  = "github.com/hashicorp/vmware"
-    }
-  }
-}
-```
-
-#### Manual installation
-
-You can find pre-built binary releases of the plugin [here](https://github.com/hashicorp/packer-plugin-name/releases).
-Once you have downloaded the latest archive corresponding to your target OS,
-uncompress it to retrieve the plugin binary file corresponding to your platform.
-To install the plugin, please follow the Packer documentation on
-[installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
-
-
-#### From Source
-
-If you prefer to build the plugin from its source code, clone the GitHub
-repository locally and run the command `go build` from the root
-directory. Upon successful compilation, a `packer-plugin-vmware` plugin
-binary file can be found in the root directory.
-To install the compiled plugin, please follow the official Packer documentation
-on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
-
-
-## Plugin Components
-
-The VMware Packer Plugin is able to create VMware virtual machines for use
-with any VMware product.
-
-The plugin comes with multiple builders able to create VMware machines,
-depending on the strategy you want to use to build the image. The supported VMware builders are:
-
-- [vmware-iso](/docs/builders/vmware-iso) - Starts from an ISO file,
+- [vmware-iso](/docs/builders/iso.mdx) - Starts from an ISO file,
   creates a brand new VMware VM, installs an OS, provisions software within
   the OS, then exports that machine to create an image. This is best for
   people who want to start from scratch.
 
-- [vmware-vmx](/docs/builders/vmware-vmx) - This builder imports an
+- [vmware-vmx](/docs/builders/vmx.mdx) - This builder imports an
   existing VMware machine (from a VMX file), runs provisioners on top of that
   VM, and exports that machine to create an image. This is best if you have
   an existing VMware VM you want to use as the source. As an additional


### PR DESCRIPTION
- Updates `README.md` to follow the same structure as the Packer Plugin for vSphere project, including adding the Requirements section.

- Simplifies `docs/README.md`  to follow the same structure as the Packer Plugin for vSphere project and remove redundant content already provided in the default README.

> **Note**: 
>
> Please review the requirements section. It is based on the content from the lower level `iso.mdx` and `vmx.mdx` content which mentions specific products. In particular, it mentioned VMware Player for Linux, but now Fusion Player (macOS) and Workstation Player (Windows and Linux) exist. As such, I kept it to Workstation Player (Linux) as it may need to be qualified for the Windows and macOS operating systems.

> **Note**: 
>
> Further pull requests for `iso.mdx` and `vmx.mdx` docs are in the works to simplify, correct, and update the content.

Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>