### PR TITLE
docs: update version in example

### DIFF
--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -37,7 +37,7 @@ packer {
   required_plugins {
     vmware = {
       version = ">= 1.0.7"
-      source = "github.com/hashicorp/packer-plugin-vmware"
+      source = "github.com/hashicorp/vmware"
     }
   }
 }

--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -36,7 +36,7 @@ Then, run [`packer init`](/docs/commands/init).
 packer {
   required_plugins {
     vmware = {
-      version = ">= 1.0.7"
+      version = ">= x.y.z"
       source = "github.com/hashicorp/vmware"
     }
   }

--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -36,8 +36,8 @@ Then, run [`packer init`](/docs/commands/init).
 packer {
   required_plugins {
     vmware = {
-      version = ">= 1.0.3"
-      source = "github.com/hashicorp/vmware"
+      version = ">= 1.0.7"
+      source = "github.com/hashicorp/packer-plugin-vmware"
     }
   }
 }


### PR DESCRIPTION
Updated version to the latest 1.0.7, and fixed the source link which was pointing to a non-existence repository on GitHub.