### PR TITLE
feat: Add SSHKeyGen Step from SDK

### DIFF
--- a/builder/vmware/common/step_vnc_boot_command.go
+++ b/builder/vmware/common/step_vnc_boot_command.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/packer-plugin-sdk/bootcommand"
+	"github.com/hashicorp/packer-plugin-sdk/communicator"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
@@ -18,12 +19,14 @@ type StepVNCBootCommand struct {
 	Config bootcommand.VNCConfig
 	VMName string
 	Ctx    interpolate.Context
+	Comm   *communicator.Config
 }
 
 type VNCBootCommandTemplateData struct {
-	HTTPIP   string
-	HTTPPort int
-	Name     string
+	HTTPIP       string
+	HTTPPort     int
+	Name         string
+	SSHPublicKey string
 }
 
 func (s *StepVNCBootCommand) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -55,9 +58,10 @@ func (s *StepVNCBootCommand) Run(ctx context.Context, state multistep.StateBag) 
 
 	hostIP := state.Get("http_ip").(string)
 	s.Ctx.Data = &VNCBootCommandTemplateData{
-		HTTPIP:   hostIP,
-		HTTPPort: httpPort,
-		Name:     s.VMName,
+		HTTPIP:       hostIP,
+		HTTPPort:     httpPort,
+		Name:         s.VMName,
+		SSHPublicKey: string(s.Comm.SSHPublicKey),
 	}
 
 	d := bootcommand.NewVNCDriver(conn, s.Config.BootKeyInterval)

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -120,6 +120,10 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		&vmwcommon.StepSuppressMessages{},
 		&vmwcommon.StepHTTPIPDiscover{},
 		commonsteps.HTTPServerFromHTTPConfig(&b.config.HTTPConfig),
+		&communicator.StepSSHKeyGen{
+			CommConf:            &b.config.Comm,
+			SSHTemporaryKeyPair: b.config.Comm.SSHTemporaryKeyPair,
+		},
 		&vmwcommon.StepConfigureVNC{
 			Enabled:            !b.config.DisableVNC && !b.config.VNCOverWebsocket,
 			VNCBindAddress:     b.config.VNCBindAddress,

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -150,6 +150,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Config: b.config.VNCConfig,
 			VMName: b.config.VMName,
 			Ctx:    b.config.ctx,
+			Comm:   &b.config.Comm,
 		},
 		&communicator.StepConnect{
 			Config:    &b.config.SSHConfig.Comm,

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -144,6 +144,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Config: b.config.VNCConfig,
 			VMName: b.config.VMName,
 			Ctx:    b.config.ctx,
+			Comm:   &b.config.Comm,
 		},
 		&communicator.StepConnect{
 			Config:    &b.config.SSHConfig.Comm,

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -111,6 +111,10 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		&vmwcommon.StepSuppressMessages{},
 		&vmwcommon.StepHTTPIPDiscover{},
 		commonsteps.HTTPServerFromHTTPConfig(&b.config.HTTPConfig),
+		&communicator.StepSSHKeyGen{
+			CommConf:            &b.config.Comm,
+			SSHTemporaryKeyPair: b.config.Comm.SSHTemporaryKeyPair,
+		},
 		&vmwcommon.StepUploadVMX{
 			RemoteType: b.config.RemoteType,
 		},

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -195,6 +195,8 @@ necessary for this build to succeed and can be found further down the page.
 
 @include 'packer-plugin-sdk/communicator/SSH-not-required.mdx'
 
+@include 'packer-plugin-sdk/communicator/SSHTemporaryKeyPair-not-required.mdx'
+
 #### Optional WinRM fields:
 
 @include 'packer-plugin-sdk/communicator/WinRM-not-required.mdx'

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -359,3 +359,74 @@ a different syntax to source a kickstart file from a mounted floppy image.
   ]
 }
 ```
+
+### SSH key pair automation
+
+The VMware builders can inject the current SSH key pair's public key into
+the template using the `SSHPublicKey` template engine. This is the SSH public
+key as a line in OpenSSH authorized_keys format.
+
+When a private key is provided using `ssh_private_key_file`, the key's
+corresponding public key can be accessed using the above engine.
+
+@include 'packer-plugin-sdk/communicator/SSH-Private-Key-File-not-required.mdx'
+
+If `ssh_password` and `ssh_private_key_file` are not specified, Packer will
+automatically generate en ephemeral key pair. The key pair's public key can
+be accessed using the template engine.
+
+For example, the public key can be provided in the boot command as a URL
+encoded string by appending `| urlquery` to the variable:
+
+In JSON:
+
+```json
+"boot_command": [
+  "<up><wait><tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg PACKER_USER={{ user `username` }} PACKER_AUTHORIZED_KEY={{ .SSHPublicKey | urlquery }}<enter>"
+]
+```
+
+In HCL2:
+
+```hcl
+boot_command = [
+  "<up><wait><tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg PACKER_USER={{ user `username` }} PACKER_AUTHORIZED_KEY={{ .SSHPublicKey | urlquery }}<enter>"
+]
+```
+
+A kickstart could then leverage those fields from the kernel command line by
+decoding the URL-encoded public key:
+
+```shell
+%post
+
+# Newly created users need the file/folder framework for SSH key authentication.
+umask 0077
+mkdir /etc/skel/.ssh
+touch /etc/skel/.ssh/authorized_keys
+
+# Loop over the command line. Set interesting variables.
+for x in $(cat /proc/cmdline)
+do
+  case $x in
+    PACKER_USER=*)
+      PACKER_USER="${x#*=}"
+      ;;
+    PACKER_AUTHORIZED_KEY=*)
+      # URL decode $encoded into $PACKER_AUTHORIZED_KEY
+      encoded=$(echo "${x#*=}" | tr '+' ' ')
+      printf -v PACKER_AUTHORIZED_KEY '%b' "${encoded//%/\\x}"
+      ;;
+  esac
+done
+
+# Create/configure packer user, if any.
+if [ -n "$PACKER_USER" ]
+then
+  useradd $PACKER_USER
+  echo "%$PACKER_USER ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/$PACKER_USER
+  [ -n "$PACKER_AUTHORIZED_KEY" ] && echo $PACKER_AUTHORIZED_KEY >> $(eval echo ~"$PACKER_USER")/.ssh/authorized_keys
+fi
+
+%end
+```

--- a/docs/builders/vmx.mdx
+++ b/docs/builders/vmx.mdx
@@ -304,3 +304,73 @@ Since ovftool is only capable of password based authentication
 - `vnc_disable_password` - This must be set to "true" when using VNC with
 ESXi 6.5 or 6.7.
 
+### SSH key pair automation
+
+The VMware builders can inject the current SSH key pair's public key into
+the template using the `SSHPublicKey` template engine. This is the SSH public
+key as a line in OpenSSH authorized_keys format.
+
+When a private key is provided using `ssh_private_key_file`, the key's
+corresponding public key can be accessed using the above engine.
+
+@include 'packer-plugin-sdk/communicator/SSH-Private-Key-File-not-required.mdx'
+
+If `ssh_password` and `ssh_private_key_file` are not specified, Packer will
+automatically generate en ephemeral key pair. The key pair's public key can
+be accessed using the template engine.
+
+For example, the public key can be provided in the boot command as a URL
+encoded string by appending `| urlquery` to the variable:
+
+In JSON:
+
+```json
+"boot_command": [
+  "<up><wait><tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg PACKER_USER={{ user `username` }} PACKER_AUTHORIZED_KEY={{ .SSHPublicKey | urlquery }}<enter>"
+]
+```
+
+In HCL2:
+
+```hcl
+boot_command = [
+  "<up><wait><tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg PACKER_USER={{ user `username` }} PACKER_AUTHORIZED_KEY={{ .SSHPublicKey | urlquery }}<enter>"
+]
+```
+
+A kickstart could then leverage those fields from the kernel command line by
+decoding the URL-encoded public key:
+
+```shell
+%post
+
+# Newly created users need the file/folder framework for SSH key authentication.
+umask 0077
+mkdir /etc/skel/.ssh
+touch /etc/skel/.ssh/authorized_keys
+
+# Loop over the command line. Set interesting variables.
+for x in $(cat /proc/cmdline)
+do
+  case $x in
+    PACKER_USER=*)
+      PACKER_USER="${x#*=}"
+      ;;
+    PACKER_AUTHORIZED_KEY=*)
+      # URL decode $encoded into $PACKER_AUTHORIZED_KEY
+      encoded=$(echo "${x#*=}" | tr '+' ' ')
+      printf -v PACKER_AUTHORIZED_KEY '%b' "${encoded//%/\\x}"
+      ;;
+  esac
+done
+
+# Create/configure packer user, if any.
+if [ -n "$PACKER_USER" ]
+then
+  useradd $PACKER_USER
+  echo "%$PACKER_USER ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/$PACKER_USER
+  [ -n "$PACKER_AUTHORIZED_KEY" ] && echo $PACKER_AUTHORIZED_KEY >> $(eval echo ~"$PACKER_USER")/.ssh/authorized_keys
+fi
+
+%end
+```

--- a/docs/builders/vmx.mdx
+++ b/docs/builders/vmx.mdx
@@ -176,6 +176,8 @@ necessary for this build to succeed and can be found further down the page.
 
 @include 'packer-plugin-sdk/communicator/SSH-not-required.mdx'
 
+@include 'packer-plugin-sdk/communicator/SSHTemporaryKeyPair-not-required.mdx'
+
 #### Optional WinRM fields:
 
 @include 'packer-plugin-sdk/communicator/WinRM-not-required.mdx'


### PR DESCRIPTION
This change adds the SSHKeyGen step from the SDK.

This step will generate a temporary ssh keypair when there is no ssh password and no ssh key configured.

The code already includes the "StepCleanupTempKeys" step which I believe does nothing without the SSHKeyGen step anyway.

Also included is the ability to use the `SSHPublicKey` variable inside the boot command, I copied this from the VirtualBox builder.

Closes #102