### PR TITLE
docs: fix references to internal documentation

### DIFF
--- a/builder/vmware/common/tools_config.go
+++ b/builder/vmware/common/tools_config.go
@@ -15,7 +15,7 @@ type ToolsConfig struct {
 	ToolsUploadFlavor string `mapstructure:"tools_upload_flavor" required:"false"`
 	// The path in the VM to upload the VMware tools. This only takes effect if
 	// `tools_upload_flavor` is non-empty. This is a [configuration
-	// template](/docs/templates/legacy_json_templates/engine) that has a single valid variable:
+	// template](/packer/docs/templates/legacy_json_templates/engine) that has a single valid variable:
 	// `Flavor`, which will be the value of `tools_upload_flavor`. By default
 	// the upload path is set to `{{.Flavor}}.iso`. This setting is not used
 	// when `remote_type` is `esx5`.

--- a/builder/vmware/iso/config.go
+++ b/builder/vmware/iso/config.go
@@ -66,7 +66,7 @@ type Config struct {
 	VMName string `mapstructure:"vm_name" required:"false"`
 
 	VMXDiskTemplatePath string `mapstructure:"vmx_disk_template_path"`
-	// Path to a [configuration template](/docs/templates/legacy_json_templates/engine) that
+	// Path to a [configuration template](/packer/docs/templates/legacy_json_templates/engine) that
 	// defines the contents of the virtual machine VMX file for VMware. The
 	// engine has access to the template variables `{{ .DiskNumber }}` and
 	// `{{ .DiskName }}`.

--- a/docs-partials/builder/vmware/common/ToolsConfig-not-required.mdx
+++ b/docs-partials/builder/vmware/common/ToolsConfig-not-required.mdx
@@ -6,7 +6,7 @@
 
 - `tools_upload_path` (string) - The path in the VM to upload the VMware tools. This only takes effect if
   `tools_upload_flavor` is non-empty. This is a [configuration
-  template](/docs/templates/legacy_json_templates/engine) that has a single valid variable:
+  template](/packer/docs/templates/legacy_json_templates/engine) that has a single valid variable:
   `Flavor`, which will be the value of `tools_upload_flavor`. By default
   the upload path is set to `{{.Flavor}}.iso`. This setting is not used
   when `remote_type` is `esx5`.

--- a/docs-partials/builder/vmware/iso/Config-not-required.mdx
+++ b/docs-partials/builder/vmware/iso/Config-not-required.mdx
@@ -30,7 +30,7 @@
 
 - `vmx_disk_template_path` (string) - VMX Disk Template Path
 
-- `vmx_template_path` (string) - Path to a [configuration template](/docs/templates/legacy_json_templates/engine) that
+- `vmx_template_path` (string) - Path to a [configuration template](/packer/docs/templates/legacy_json_templates/engine) that
   defines the contents of the virtual machine VMX file for VMware. The
   engine has access to the template variables `{{ .DiskNumber }}` and
   `{{ .DiskName }}`.

--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -15,12 +15,12 @@ Packer actually comes with multiple builders able to create VMware machines,
 depending on the strategy you want to use to build the image. Packer supports
 the following VMware builders:
 
-- [vmware-iso](/docs/builders/vmware-iso) - Starts from an ISO file,
+- [vmware-iso](/packer/plugins/builders/vmware/iso) - Starts from an ISO file,
   creates a brand new VMware VM, installs an OS, provisions software within
   the OS, then exports that machine to create an image. This is best for
   people who want to start from scratch.
 
-- [vmware-vmx](/docs/builders/vmware-vmx) - This builder imports an
+- [vmware-vmx](/packer/plugins/builders/vmware/vmx) - This builder imports an
   existing VMware machine (from a VMX file), runs provisioners on top of that
   VM, and exports that machine to create an image. This is best if you have
   an existing VMware VM you want to use as the source. As an additional
@@ -30,7 +30,7 @@ the following VMware builders:
 ## How to use this plugin
 
 From Packer v1.7.0, copy and paste this code into your Packer configuration to install this plugin.
-Then, run [`packer init`](/docs/commands/init).
+Then, run [`packer init`](/packer/docs/commands/init).
 
 ```hcl
 packer {

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -262,7 +262,7 @@ $ esxcli system settings advanced set -o /Net/GuestIPHack -i 1
 When using a remote VMware Hypervisor, the builder still downloads the ISO and
 various files locally, and uploads these to the remote machine. Packer currently
 uses SSH to communicate to the ESXi machine rather than the vSphere API.
-If you want to use vSphere API, see the [vsphere-iso](/docs/builders/vsphere/vsphere-iso) builder.
+If you want to use vSphere API, see the [vsphere-iso](/packer/plugins/builders/vsphere/vsphere-iso) builder.
 
 Packer also requires VNC to issue boot commands during a build, which may be
 disabled on some remote VMware Hypervisors. Please consult the appropriate

--- a/docs/builders/vmx.mdx
+++ b/docs/builders/vmx.mdx
@@ -255,7 +255,7 @@ $ esxcli system settings advanced set -o /Net/GuestIPHack -i 1
 When using a remote VMware Hypervisor, the builder still downloads the ISO and
 various files locally, and uploads these to the remote machine. Packer currently
 uses SSH to communicate to the ESXi machine rather than the vSphere API.
-If you want to use vSphere API, see the [vsphere-iso](/docs/builders/vsphere/vsphere-iso) builder.
+If you want to use vSphere API, see the [vsphere-iso](/packer/plugins/builders/vsphere/vsphere-iso) builder.
 
 Packer also requires VNC to issue boot commands during a build, which may be
 disabled on some remote VMware Hypervisors. Please consult the appropriate


### PR DESCRIPTION
With the move to developer.hashicorp.com some links between the general doc and plugins were broken. This PR fixes them