### PR TITLE
.gitignore: ignore .docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ main
 dist/*
 packer-plugin-vmware
 example/output-example/
+.docs


### PR DESCRIPTION
The .docs directory is generated, and should therefore not be tracked by Git.