### PR TITLE
fix: fusion 13 x86_x64 vmware tools location

### DIFF
--- a/builder/vmware/common/driver_fusion6.go
+++ b/builder/vmware/common/driver_fusion6.go
@@ -137,7 +137,7 @@ func (d *Fusion6Driver) ToolsIsoPath(k string) string {
 	if err := cmd.Run(); err != nil {
 		log.Printf("[DEBUG] failed to execute vmware-vmx command to get version %v", err)
 		log.Printf("[DEBUG] continuing with default iso path for fusion6+.")
-		return filepath.Join(d.AppPath, "Contents", "Library", "isoimages", "x86_64", k+".iso")
+		return filepath.Join(d.AppPath, "Contents", "Library", "isoimages", "x86_x64", k+".iso")
 	}
 	versionRe := regexp.MustCompile(`(?i)VMware [a-z0-9-]+ (\d+)\.`)
 	matches := versionRe.FindStringSubmatch(stderr.String())
@@ -148,7 +148,7 @@ func (d *Fusion6Driver) ToolsIsoPath(k string) string {
 		return filepath.Join(d.AppPath, "Contents", "Library", "isoimages", "arm64", k+".iso")
 	}
 
-	return filepath.Join(d.AppPath, "Contents", "Library", "isoimages", "x86_64", k+".iso")
+	return filepath.Join(d.AppPath, "Contents", "Library", "isoimages", "x86_x64", k+".iso")
 }
 
 func (d *Fusion6Driver) GetVmwareDriver() VmwareDriver {


### PR DESCRIPTION
This is a hotfix to amend a previous PR supporting VMWare Fusion 13 and it's updated VMTools paths (https://github.com/hashicorp/packer-plugin-vmware/pull/112) 

Closes #137 

