### PR TITLE
Combines the example preseed/late_command and updates example iso url to stable 11.7 endpoint

### DIFF
--- a/example/data/debian/preseed.pkrtpl.hcl
+++ b/example/data/debian/preseed.pkrtpl.hcl
@@ -101,7 +101,6 @@ tasksel tasksel/first multiselect standard, ssh-server
 
 # Setup passwordless sudo for packer user
 d-i preseed/late_command string \
-echo "vagrant ALL=(ALL:ALL) NOPASSWD:ALL" > /target/etc/sudoers.d/vagrant && chmod 0440 /target/etc/sudoers.d/vagrant
-
+echo "vagrant ALL=(ALL:ALL) NOPASSWD:ALL" > /target/etc/sudoers.d/vagrant && chmod 0440 /target/etc/sudoers.d/vagrant; \
 # remove cdrom from apt sources
-d-i preseed/late_command string sed -i '/^deb cdrom:/s/^/#/' /target/etc/apt/sources.list
+sed -i '/^deb cdrom:/s/^/#/' /target/etc/apt/sources.list

--- a/example/pkrvars/debian/fusion-12.pkrvars.hcl
+++ b/example/pkrvars/debian/fusion-12.pkrvars.hcl
@@ -1,11 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-iso_url          = "https://cdimage.debian.org/debian-cd/current/amd64/iso-dvd/debian-11.6.0-amd64-DVD-1.iso"
-iso_checksum     = "55f6f49b32d3797621297a9481a6cc3e21b3142f57d8e1279412ff5a267868d8"
+iso_url          = "https://cdimage.debian.org/cdimage/archive/11.7.0/amd64/iso-dvd/debian-11.7.0-amd64-DVD-1.iso"
+iso_checksum     = "cfbb1387d92c83f49420eca06e2d11a23e5a817a21a5d614339749634709a32f"
 data_directory   = "data/debian"
 guest_os_type    = "debian-64"
 hardware_version = 19
 boot_command     = ["<wait><esc><wait>auto preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg netcfg/get_hostname={{ .Name }}<enter>"]
 vm_name          = "debian_x86_64"
-

--- a/example/pkrvars/debian/fusion-13.pkrvars.hcl
+++ b/example/pkrvars/debian/fusion-13.pkrvars.hcl
@@ -5,8 +5,8 @@ cdrom_adapter_type   = "sata"
 data_directory       = "data/debian"
 disk_adapter_type    = "sata"
 network_adapter_type = "e1000e"
-iso_url              = "https://cdimage.debian.org/debian-cd/current/arm64/iso-dvd/debian-11.6.0-arm64-DVD-1.iso"
-iso_checksum         = "b27ff768c10808518790d72d670c5588cdc60cf8934ef92773a89274a193a65f"
+iso_url              = "https://cdimage.debian.org/cdimage/archive/11.7.0/arm64/iso-dvd/debian-11.7.0-arm64-DVD-1.iso"
+iso_checksum         = "3b0d304379b671d7b7091631765f87e1cbb96b9f03f8e9a595a2bf540c789f3f"
 guest_os_type        = "arm-debian-64"
 hardware_version     = 20
 boot_command         = ["<wait><up>e<wait><down><down><down><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><wait>install <wait> preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg <wait>debian-installer=en_US.UTF-8 <wait>auto <wait>locale=en_US.UTF-8 <wait>kbd-chooser/method=us <wait>keyboard-configuration/xkb-keymap=us <wait>netcfg/get_hostname={{ .Name }} <wait>netcfg/get_domain={{ .Name }} <wait>fb=false <wait>debconf/frontend=noninteractive <wait>console-setup/ask_detect=false <wait>console-keymaps-at/keymap=us <wait>grub-installer/bootdev=/dev/sda <wait><f10><wait>"]
@@ -17,5 +17,3 @@ vmx_data = {
   "svga.autodetect"         = true
   "usb_xhci.present"        = true
 }
-
-


### PR DESCRIPTION
This PR addressed a number of issues that I ran into when testing the provided example. The first issue is the iso url in the example is no longer valid. I updated it to 11.7 the latest minor version of bullseye that has a stable endpoint. The next issue addressed in this pr is in the supplied preseed file. I noticed in testing that the `vagrant` user could not do passwordless sudo. Upon further inspection I could see in `/var/log/installer/syslog` that only the last `sed` late_command was ran. I did some digging and found a number of random SO posts/comments that claimed you can only have a single preseed/late_command. I attempted to find some official Debian documentation that supported that claim and [this](https://lists.debian.org/debian-boot/2016/04/msg00326.html).

This was tested on an M1 mac running VMWare Fusion 13. I verified that with this change passwordless sudo was enabled for the `vagrant` user and the `cdrom` source was commented out of the `source.list` file.

I had a coworker test this change on an intel Mac and they said it 'worked' though I was not there to validate what 'worked' meant to them.

