### PR TITLE
chore: address io/ioutil depreciation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -120,7 +120,7 @@ linters-settings:
     # [deprecated] comma-separated list of pairs of the form pkg:regex
     # the regex is used to ignore names within pkg. (default "fmt:.*").
     # see https://github.com/kisielk/errcheck#the-deprecated-method for details
-    ignore: fmt:.*,io/ioutil:^Read.*,io:Close
+    ignore: fmt:.*,io:Close
 
     # path to a file containing a list of functions to exclude from checking
     # see https://github.com/kisielk/errcheck#excluding-functions for details

--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"os"
@@ -247,7 +247,7 @@ func readVMXConfig(path string) (map[string]string, error) {
 	}
 	defer f.Close()
 
-	vmxBytes, err := ioutil.ReadAll(f)
+	vmxBytes, err := io.ReadAll(f)
 	if err != nil {
 		return map[string]string{}, err
 	}

--- a/builder/vmware/common/driver_fusion5.go
+++ b/builder/vmware/common/driver_fusion5.go
@@ -6,7 +6,6 @@ package common
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -127,7 +126,7 @@ func (d *Fusion5Driver) SuppressMessages(vmxPath string) error {
 	base = strings.Replace(base, ".vmx", "", -1)
 
 	plistPath := filepath.Join(dir, base+".plist")
-	return ioutil.WriteFile(plistPath, []byte(fusionSuppressPlist), 0644)
+	return os.WriteFile(plistPath, []byte(fusionSuppressPlist), 0644)
 }
 
 func (d *Fusion5Driver) Verify() error {

--- a/builder/vmware/common/ssh_config_test.go
+++ b/builder/vmware/common/ssh_config_test.go
@@ -4,7 +4,6 @@
 package common
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -53,7 +52,7 @@ func TestSSHConfigPrepare_SSHPrivateKey(t *testing.T) {
 	}
 
 	// Test bad contents
-	tf, err := ioutil.TempFile("", "packer")
+	tf, err := os.CreateTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/builder/vmware/common/step_clean_vmx_test.go
+++ b/builder/vmware/common/step_clean_vmx_test.go
@@ -5,7 +5,6 @@ package common
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -39,7 +38,7 @@ func TestStepCleanVMX_floppyPath(t *testing.T) {
 
 	vmxPath := testVMXFile(t)
 	defer os.Remove(vmxPath)
-	if err := ioutil.WriteFile(vmxPath, []byte(testVMXFloppyPath), 0644); err != nil {
+	if err := os.WriteFile(vmxPath, []byte(testVMXFloppyPath), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -58,7 +57,7 @@ func TestStepCleanVMX_floppyPath(t *testing.T) {
 	}
 
 	// Test the resulting data
-	vmxContents, err := ioutil.ReadFile(vmxPath)
+	vmxContents, err := os.ReadFile(vmxPath)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -92,7 +91,7 @@ func TestStepCleanVMX_isoPath(t *testing.T) {
 
 	vmxPath := testVMXFile(t)
 	defer os.Remove(vmxPath)
-	if err := ioutil.WriteFile(vmxPath, []byte(testVMXISOPath), 0644); err != nil {
+	if err := os.WriteFile(vmxPath, []byte(testVMXISOPath), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -111,7 +110,7 @@ func TestStepCleanVMX_isoPath(t *testing.T) {
 	}
 
 	// Test the resulting data
-	vmxContents, err := ioutil.ReadFile(vmxPath)
+	vmxContents, err := os.ReadFile(vmxPath)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -148,7 +147,7 @@ func TestStepCleanVMX_ethernet(t *testing.T) {
 
 	vmxPath := testVMXFile(t)
 	defer os.Remove(vmxPath)
-	if err := ioutil.WriteFile(vmxPath, []byte(testVMXEthernet), 0644); err != nil {
+	if err := os.WriteFile(vmxPath, []byte(testVMXEthernet), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -167,7 +166,7 @@ func TestStepCleanVMX_ethernet(t *testing.T) {
 	}
 
 	// Test the resulting data
-	vmxContents, err := ioutil.ReadFile(vmxPath)
+	vmxContents, err := os.ReadFile(vmxPath)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/builder/vmware/common/step_configure_vmx_test.go
+++ b/builder/vmware/common/step_configure_vmx_test.go
@@ -5,7 +5,6 @@ package common
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -14,7 +13,7 @@ import (
 )
 
 func testVMXFile(t *testing.T) string {
-	tf, err := ioutil.TempFile("", "packer")
+	tf, err := os.CreateTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -53,7 +52,7 @@ func TestStepConfigureVMX(t *testing.T) {
 	}
 
 	// Test the resulting data
-	vmxContents, err := ioutil.ReadFile(vmxPath)
+	vmxContents, err := os.ReadFile(vmxPath)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -106,7 +105,7 @@ func TestStepConfigureVMX_floppyPath(t *testing.T) {
 	}
 
 	// Test the resulting data
-	vmxContents, err := ioutil.ReadFile(vmxPath)
+	vmxContents, err := os.ReadFile(vmxPath)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -180,7 +179,7 @@ func TestStepConfigureVMX_generatedAddresses(t *testing.T) {
 	}
 
 	// Test the resulting data
-	vmxContents, err := ioutil.ReadFile(vmxPath)
+	vmxContents, err := os.ReadFile(vmxPath)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/builder/vmware/common/step_output_dir_test.go
+++ b/builder/vmware/common/step_output_dir_test.go
@@ -5,7 +5,6 @@ package common
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -13,7 +12,7 @@ import (
 )
 
 func testOutputDir(t *testing.T) string {
-	td, err := ioutil.TempDir("", "packer")
+	td, err := os.MkdirTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/builder/vmware/common/step_prepare_tools_test.go
+++ b/builder/vmware/common/step_prepare_tools_test.go
@@ -5,7 +5,6 @@ package common
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -17,7 +16,7 @@ func TestStepPrepareTools_impl(t *testing.T) {
 }
 
 func TestStepPrepareTools(t *testing.T) {
-	tf, err := ioutil.TempFile("", "packer")
+	tf, err := os.CreateTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/builder/vmware/common/step_shutdown_test.go
+++ b/builder/vmware/common/step_shutdown_test.go
@@ -5,7 +5,6 @@ package common
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +15,7 @@ import (
 )
 
 func testLocalOutputDir(t *testing.T) *LocalOutputDir {
-	td, err := ioutil.TempDir("", "packer")
+	td, err := os.MkdirTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -157,7 +156,7 @@ func TestStepShutdown_locks(t *testing.T) {
 
 	// Create some lock files
 	lockPath := filepath.Join(dir.dir, "nope.lck")
-	err := ioutil.WriteFile(lockPath, []byte("foo"), 0644)
+	err := os.WriteFile(lockPath, []byte("foo"), 0644)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/builder/vmware/common/vmx.go
+++ b/builder/vmware/common/vmx.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"regexp"
@@ -101,7 +100,7 @@ func WriteVMX(path string, data map[string]string) (err error) {
 
 // ReadVMX takes a path to a VMX file and reads it into a k/v mapping.
 func ReadVMX(path string) (map[string]string, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/builder/vmware/iso/builder_acc_test.go
+++ b/builder/vmware/iso/builder_acc_test.go
@@ -5,7 +5,7 @@ package iso
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -16,7 +16,7 @@ import (
 
 func TestBuilderAcc_basic(t *testing.T) {
 	templatePath := filepath.Join("testdata", "minimal.json")
-	bytes, err := ioutil.ReadFile(templatePath)
+	bytes, err := os.ReadFile(templatePath)
 	if err != nil {
 		t.Fatalf("failed to load template file %s", templatePath)
 	}

--- a/builder/vmware/iso/builder_test.go
+++ b/builder/vmware/iso/builder_test.go
@@ -5,7 +5,6 @@ package iso
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -403,7 +402,7 @@ func TestBuilderPrepare_OutputDir(t *testing.T) {
 	config := testConfig()
 
 	// Test with existing dir
-	dir, err := ioutil.TempDir("", "packer")
+	dir, err := os.MkdirTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -487,7 +486,7 @@ func TestBuilderPrepare_VMXTemplatePath(t *testing.T) {
 	}
 
 	// Test good
-	tf, err := ioutil.TempFile("", "packer")
+	tf, err := os.CreateTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -509,7 +508,7 @@ func TestBuilderPrepare_VMXTemplatePath(t *testing.T) {
 	}
 
 	// Bad template
-	tf2, err := ioutil.TempFile("", "packer")
+	tf2, err := os.CreateTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/builder/vmware/iso/config.go
+++ b/builder/vmware/iso/config.go
@@ -8,7 +8,7 @@ package iso
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -265,7 +265,7 @@ func (c *Config) validateVMXTemplatePath() error {
 	}
 	defer f.Close()
 
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -6,7 +6,7 @@ package iso
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -89,7 +89,7 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 		}
 		defer f.Close()
 
-		rawBytes, err := ioutil.ReadAll(f)
+		rawBytes, err := io.ReadAll(f)
 		if err != nil {
 			err := fmt.Errorf("Error reading VMX template: %s", err)
 			state.Put("error", err)
@@ -140,7 +140,7 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 				}
 				defer f.Close()
 
-				rawBytes, err := ioutil.ReadAll(f)
+				rawBytes, err := io.ReadAll(f)
 				if err != nil {
 					err := fmt.Errorf("Error reading VMX disk template: %s", err)
 					state.Put("error", err)

--- a/builder/vmware/iso/step_create_vmx_test.go
+++ b/builder/vmware/iso/step_create_vmx_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -45,7 +45,7 @@ func readFloppyOutput(path string) (string, error) {
 		return "", fmt.Errorf("Unable to open file %s", path)
 	}
 	defer f.Close()
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return "", fmt.Errorf("Unable to read file: %s", err)
 	}

--- a/builder/vmware/vmx/builder_test.go
+++ b/builder/vmware/vmx/builder_test.go
@@ -5,7 +5,6 @@ package vmx
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -16,7 +15,7 @@ import (
 func TestBuilderPrepare_FloppyFiles(t *testing.T) {
 	var b Builder
 
-	tf, err := ioutil.TempFile("", "packer")
+	tf, err := os.CreateTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/builder/vmware/vmx/config_test.go
+++ b/builder/vmware/vmx/config_test.go
@@ -4,7 +4,6 @@
 package vmx
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -49,7 +48,7 @@ func TestNewConfig_sourcePath(t *testing.T) {
 	testConfigErr(t, warns, errs)
 
 	// Good
-	tf, err := ioutil.TempFile("", "packer")
+	tf, err := os.CreateTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/builder/vmware/vmx/step_clone_vmx_test.go
+++ b/builder/vmware/vmx/step_clone_vmx_test.go
@@ -6,7 +6,6 @@ package vmx
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,7 +28,7 @@ func TestStepCloneVMX_impl(t *testing.T) {
 
 func TestStepCloneVMX(t *testing.T) {
 	// Setup some state
-	td, err := ioutil.TempDir("", "packer")
+	td, err := os.MkdirTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -53,13 +52,13 @@ func TestStepCloneVMX(t *testing.T) {
 
 	// Create the source
 	sourcePath := filepath.Join(td, "source.vmx")
-	if err := ioutil.WriteFile(sourcePath, []byte(testCloneVMX), 0644); err != nil {
+	if err := os.WriteFile(sourcePath, []byte(testCloneVMX), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
 	// Create the dest because the mock driver won't
 	destPath := filepath.Join(td, "foo.vmx")
-	if err := ioutil.WriteFile(destPath, []byte(testCloneVMX), 0644); err != nil {
+	if err := os.WriteFile(destPath, []byte(testCloneVMX), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 


### PR DESCRIPTION
### Summary

`io/ioutil` is deprecated as of Go 1.16:

- Updates `ioutil.TempDir` to `os.MkdirTemp`.
- Updates `ioutil.TempFile` to `os.CreateTemp`.
- Updates `ioutil.ReadFile` to `os.ReadFile`.
- Updates `ioutil.WriteFile` to `os.WriteFile`.
- Updates `ioutil.ReadAll` to `io.ReadAll`.

### Testing

```console
packer-plugin-vmware on  chore/ioutil-depreciation via 🐹 v1.22.3 
➜ make generate
2024/05/11 01:00:04 Copying "docs" to ".docs/"
2024/05/11 01:00:04 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...


packer-plugin-vmware on  chore/ioutil-depreciation via 🐹 v1.22.3 
➜ make build   


packer-plugin-vmware on  chore/ioutil-depreciation via 🐹 v1.22.3 took 2.6s 
➜ make test    
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 6.592s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    1.774s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    2.175s
```