### PR TITLE
chore(deps): bump golang/x/net from 0.21.0 to 0.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/vmware/govmomi v0.37.1
 	github.com/zclconf/go-cty v1.13.3
 	golang.org/x/crypto v0.23.0
-	golang.org/x/net v0.21.0
+	golang.org/x/net v0.25.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -399,8 +399,8 @@ golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
-golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=
-golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
+golang.org/x/net v0.25.0 h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac=
+golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.11.0 h1:vPL4xzxBM4niKCW6g9whtaWVXTJf1U5e4aZxxFx/gbU=


### PR DESCRIPTION
### Summary

Bump golang/x/net from 0.21.0 to 0.25.0.

- GHSA-4v7x-pqxf-cx7m

Ref: https://github.com/hashicorp/packer-plugin-vmware/security/dependabot/26

### Testing

```shell
➜  packer-plugin-vmware git:(chore(deps)/golang-x-net) go get -u golang.org/x/net
go: downloading golang.org/x/net v0.25.0
➜  packer-plugin-vmware git:(chore(deps)/golang-x-net) ✗ go mod tidy
➜  packer-plugin-vmware git:(chore(deps)/golang-x-net) ✗ make build
➜  packer-plugin-vmware git:(chore(deps)/golang-x-net) ✗ make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 7.111s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    2.917s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    3.796s
```
