### PR TITLE
chore: address trailingcomma depreciation

### DIFF
--- a/builder/vmware/common/driver_esx5.go
+++ b/builder/vmware/common/driver_esx5.go
@@ -920,7 +920,6 @@ func (d *ESX5Driver) esxcli(args ...string) (*esxcliReader, error) {
 		return nil, err
 	}
 	r := csv.NewReader(bytes.NewReader(stdout.Bytes()))
-	r.TrailingComma = true
 	header, err := r.Read()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Summary

TrailingComma has been deprecated since Go 1.2.

### Testing

```shell
packer-plugin-vmware on  chore/trailingcomma-depreciation via 🐹 v1.22.3 
➜ make generate
2024/05/14 19:17:46 Copying "docs" to ".docs/"
2024/05/14 19:17:46 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...


packer-plugin-vmware on  chore/trailingcomma-depreciation via 🐹 v1.22.3 
➜ make build   


packer-plugin-vmware on  chore/trailingcomma-depreciation via 🐹 v1.22.3 took 3.0s 
➜ make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 6.606s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    1.827s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    2.176s
```