### PR TITLE
chore: replace `reflect.DeepEqual`

### DIFF
--- a/builder/vmware/common/driver_config_test.go
+++ b/builder/vmware/common/driver_config_test.go
@@ -5,10 +5,8 @@ package common
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 )
 
@@ -74,12 +72,12 @@ func TestDriverConfigPrepare(t *testing.T) {
 	for _, c := range tc {
 		t.Run(c.name, func(t *testing.T) {
 			errs := c.config.Prepare(interpolate.NewContext())
-			if !reflect.DeepEqual(errs, c.errs) {
+			if len(errs) != len(c.errs) {
 				t.Fatalf("bad: \n expected '%v' \nactual '%v'", c.errs, errs)
 			}
-			if len(c.errs) == 0 {
-				if diff := cmp.Diff(c.config, c.expectedConfig); diff != "" {
-					t.Fatalf("bad value: %s", diff)
+			for i, err := range errs {
+				if err.Error() != c.errs[i].Error() {
+					t.Fatalf("bad: \n expected '%v' \nactual '%v'", c.errs[i], err)
 				}
 			}
 		})

--- a/builder/vmware/common/run_config_test.go
+++ b/builder/vmware/common/run_config_test.go
@@ -5,7 +5,6 @@ package common
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -24,7 +23,7 @@ func TestRunConfig_Prepare(t *testing.T) {
 		warnings       []string
 	}{
 		{
-			name:   "VNC dafaults",
+			name:   "VNC defaults",
 			config: &RunConfig{},
 			expectedConfig: &RunConfig{
 				VNCPortMin:     5900,
@@ -103,8 +102,13 @@ func TestRunConfig_Prepare(t *testing.T) {
 	for _, c := range tc {
 		t.Run(c.name, func(t *testing.T) {
 			warnings, errs := c.config.Prepare(interpolate.NewContext(), c.driver)
-			if !reflect.DeepEqual(errs, c.errs) {
+			if len(errs) != len(c.errs) {
 				t.Fatalf("bad: \n expected '%v' \nactual '%v'", c.errs, errs)
+			}
+			for i, err := range errs {
+				if err.Error() != c.errs[i].Error() {
+					t.Fatalf("bad: \n expected '%v' \nactual '%v'", c.errs[i], err)
+				}
 			}
 			if diff := cmp.Diff(warnings, c.warnings); diff != "" {
 				t.Fatalf("unexpected warnings: %s", diff)


### PR DESCRIPTION
### Summary

Replaces the use of `reflect.DeepEqual` with `errors.Is` for error comparison.

### Testing

```console
packer-plugin-vmware on  chore/replace-reflect.DeepEqual [!] via 🐹 v1.22.3 
➜ make generate
2024/05/25 00:44:22 Copying "docs" to ".docs/"
2024/05/25 00:44:22 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vmware on  chore/replace-reflect.DeepEqual [!] via 🐹 v1.22.3 took 4.7s 
➜ make build   

packer-plugin-vmware on  chore/replace-reflect.DeepEqual [!] via 🐹 v1.22.3 took 3.0s 
➜ make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 6.592s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    1.839s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    2.230s
```
