### PR TITLE
Add support for  .vhd files

### DIFF
--- a/builder/vmware/common/step_clean_files.go
+++ b/builder/vmware/common/step_clean_files.go
@@ -16,7 +16,7 @@ import (
 // These are the extensions of files that are important for the function
 // of a VMware virtual machine. Any other file is discarded as part of the
 // build.
-var KeepFileExtensions = []string{".nvram", ".vmdk", ".vmsd", ".vmx", ".vmxf"}
+var KeepFileExtensions = []string{".nvram", ".vmdk", ".vmsd", ".vmx", ".vmxf", ".vhd"}
 
 // This step removes unnecessary files from the final result.
 //

--- a/builder/vmware/common/step_create_disks.go
+++ b/builder/vmware/common/step_create_disks.go
@@ -27,7 +27,10 @@ type StepCreateDisks struct {
 func (s *StepCreateDisks) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packersdk.Ui)
-	isoPath := state.Get("iso_path").(string)
+	isoPath, err := state.Get("iso_path").(string)
+	if !err {
+		isoPath = ""
+	}
 
 	ui.Say("Creating required virtual machine disks")
 

--- a/builder/vmware/common/step_create_disks.go
+++ b/builder/vmware/common/step_create_disks.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"path"
 	"path/filepath"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
@@ -36,7 +35,7 @@ func (s *StepCreateDisks) Run(ctx context.Context, state multistep.StateBag) mul
 	// first collate all the disk requirements
 	var diskFullPaths, diskSizes []string
 	// The 'main' or 'default' disk, only used in vmware-iso
-	if s.CreateMainDisk && path.Ext(isoPath) != ".vhd" {
+	if s.CreateMainDisk && filepath.Ext(isoPath) != ".vhd" {
 		diskFullPaths = append(diskFullPaths, filepath.Join(*s.OutputDir, s.DiskName+".vmdk"))
 		diskSizes = append(diskSizes, fmt.Sprintf("%dM", uint64(s.MainDiskSize)))
 	}

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -112,7 +112,7 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 			return multistep.ActionHalt
 		}
 		// If running on windows, we need to replace the slashes with backslashes
-		if runtime.GOOS == "windows" {
+		if runtime.GOOS == "windows" && config.RemoteType == "" {
 			diskName = strings.Replace(isoPath, "/", "\\", -1)
 		} else {
 			diskName = isoPath

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -87,7 +87,8 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 	if config.RemoteType != "" {
 		// For remote builds, we just put the VMX in a temporary
 		// directory since it just gets uploaded anyways.
-		vmxDir, err := tmp.Dir("vmw-iso")
+		var err error
+		vmxDir, err = tmp.Dir("vmw-iso")
 		if err != nil {
 			err := fmt.Errorf("error preparing VMX template: %s", err)
 			state.Put("error", err)

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -18,7 +17,7 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 	"github.com/hashicorp/packer-plugin-sdk/tmp"
-	common "github.com/hashicorp/packer-plugin-vmware/builder/vmware/common"
+	"github.com/hashicorp/packer-plugin-vmware/builder/vmware/common"
 )
 
 type vmxTemplateData struct {

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -16,7 +17,7 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 	"github.com/hashicorp/packer-plugin-sdk/tmp"
-	"github.com/hashicorp/packer-plugin-vmware/builder/vmware/common"
+	common "github.com/hashicorp/packer-plugin-vmware/builder/vmware/common"
 )
 
 type vmxTemplateData struct {
@@ -179,7 +180,7 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 	templateData := vmxTemplateData{
 		Name:            config.VMName,
 		GuestOS:         config.GuestOSType,
-		DiskName:        config.DiskName,
+		DiskName:        diskName,
 		Version:         strconv.Itoa(config.Version),
 		ISOPath:         isoPath,
 		IsVHD:           filepath.Ext(isoPath) == ".vhd",

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -172,7 +173,11 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 
 	var diskName string
 	if filepath.Ext(isoPath) == ".vhd" {
-		diskName = strings.Replace(isoPath, "/", "\\", -1)
+		if runtime.GOOS == "windows" {
+			diskName = strings.Replace(isoPath, "/", "\\", -1)
+		} else {
+			diskName = isoPath
+		}
 	} else {
 		diskName = config.DiskName + ".vmdk"
 	}


### PR DESCRIPTION
This PR adds support for `.vhd` files.

Before this PR, when using a `.vhd` as the `iso_url` (as stated possible in the [documentation](https://developer.hashicorp.com/packer/integrations/hashicorp/vmware/latest/components/builder/iso#required:)), VMWare could not attach the disk.

This solves the issue by checking the extension of the file and, if it is `.vhd`, by changing the way the disk is mounted within the `.vmx` file template.

It also copy the base `.vhd` to a the vmx directory to ensure that the base `.vhd` stays untouched. I decided to use the vmx directory after reading [in the documentation](https://developer.hashicorp.com/packer/integrations/hashicorp/vmware/latest/components/builder/iso#optional:) 
> Packer will not delete the vmx and vmdk files; this is left up to the user if you don't want to keep those files.

in case of local build, and seeing [in code](https://github.com/remi-espie/packer-plugin-vmware/blob/5f7f0d32156b70c65ad5f44054252ab1180a37cb/builder/vmware/iso/step_create_vmx.go#L83) that it is located in a temporary directory that will be deleted in case of remote build.

Closes #207