### PR TITLE
feat: check ovftool version

### DIFF
--- a/builder/vmware/common/driver_esx5.go
+++ b/builder/vmware/common/driver_esx5.go
@@ -355,7 +355,7 @@ func (d *ESX5Driver) VerifyOvfTool(SkipExport, skipValidateCredentials bool) err
 	// check that password is valid by sending a dummy ovftool command
 	// now, so that we don't fail for a simple mistake after a long
 	// build
-	ovftool := GetOVFTool()
+	ovftool := GetOvfTool()
 
 	if d.Password == "" {
 		return fmt.Errorf("exporting the vm from esxi with ovftool requires " +

--- a/builder/vmware/common/step_export.go
+++ b/builder/vmware/common/step_export.go
@@ -93,7 +93,7 @@ func (s *StepExport) Run(ctx context.Context, state multistep.StateBag) multiste
 
 	var args, ui_args []string
 
-	ovftool := GetOVFTool()
+	ovftool := GetOvfTool()
 	if c.RemoteType == "esx5" {
 		// Generate arguments for the ovftool command, but obfuscating the
 		// password that we can log the command to the UI for debugging.


### PR DESCRIPTION
### Description

Checks the minimum recommended version of VMware Open Virtualization Format Tool ('ovftool').

Sets the minimum recommended to 4.6.0 to support vSphere 8.0 and earlier.

Also improves the documentation for Export Configuration that uses `ovftool`.

### Testing

✅ Basic Tests

```console
packer-plugin-vmware on  feat/check-ovftool-version
✦ ➜ go fmt ./...

packer-plugin-vmware on  feat/check-ovftool-version
✦ ➜ make generate
2024/08/08 18:43:42 Copying "docs" to ".docs/"
2024/08/08 18:43:42 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vmware on  feat/check-ovftool-version
✦ ➜ make build

packer-plugin-vmware on  feat/check-ovftool-version
✦ ➜ make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 7.199s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    3.096s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    4.169s
```

✅ Unit Tests

1. OVFTool not installed.

```console
✦4 ➜ PACKER_LOG=1 PACKER_LOG_PATH=packer.log packer build --force -var-file=photon-4.0-R2.pkrvars.hcl .
vmware-iso.vagrant-vmw: output will be in this color.

Build 'vmware-iso.vagrant-vmw' errored after 179 milliseconds 114 microseconds: ovftool not found; install and include it in your PATH

==> Wait completed after 179 milliseconds 223 microseconds

==> Some builds didn't complete successfully and had errors:
--> vmware-iso.vagrant-vmw: ovftool not found; install and include it in your PATH
```

2. OVFTool < 4.6.0

```console
2024/08/08 18:40:36 packer-plugin-vmware_v1.0.12-dev_x5.0_darwin_amd64 plugin: 2024/08/08 18:40:36 Verifying that ovftool exists...
2024/08/08 18:40:36 packer-plugin-vmware_v1.0.12-dev_x5.0_darwin_amd64 plugin: 2024/08/08 18:40:36 Checking ovftool version...
2024/08/08 18:40:38 packer-plugin-vmware_v1.0.12-dev_x5.0_darwin_amd64 plugin: 2024/08/08 18:40:38 Returned ovftool version: VMware ovftool 4.5.0 (build-20459872)
2024/08/08 18:40:38 packer-plugin-vmware_v1.0.12-dev_x5.0_darwin_amd64 plugin: .
2024/08/08 18:40:38 packer-plugin-vmware_v1.0.12-dev_x5.0_darwin_amd64 plugin: 2024/08/08 18:40:38 [WARN] The version of ovftool (4.5.0) is below the minimum recommended version (4.6.0). Please download the latest version from https://developer.broadcom.com/tools/open-virtualization-format-ovf-tool/latest.
```

3. OVFTool >= 4.6.0

```console
2024/08/08 18:42:21 packer-plugin-vmware_v1.0.12-dev_x5.0_darwin_amd64 plugin: 2024/08/08 18:42:21 Verifying that ovftool exists...
2024/08/08 18:42:21 packer-plugin-vmware_v1.0.12-dev_x5.0_darwin_amd64 plugin: 2024/08/08 18:42:21 Checking ovftool version...
2024/08/08 18:42:23 packer-plugin-vmware_v1.0.12-dev_x5.0_darwin_amd64 plugin: 2024/08/08 18:42:23 Returned ovftool version: VMware ovftool 4.6.3 (build-24031167)
2024/08/08 18:42:23 packer-plugin-vmware_v1.0.12-dev_x5.0_darwin_amd64 plugin: .
2024/08/08 18:42:23 ui: [1;32m==> vmware-iso.vagrant-vmw: Retrieving ISO[0m
```

### Reference

Closes #135