### PR TITLE
fix: update `StepSSHKeyGen` position

### DIFF
--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -74,6 +74,10 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			RemoteType:   b.config.RemoteType,
 			VMName:       b.config.VMName,
 		},
+		multistep.If(b.config.Comm.Type == "ssh", &communicator.StepSSHKeyGen{
+			CommConf:            &b.config.Comm,
+			SSHTemporaryKeyPair: b.config.Comm.SSHTemporaryKeyPair,
+		}),
 		&commonsteps.StepCreateFloppy{
 			Files:       b.config.FloppyConfig.FloppyFiles,
 			Directories: b.config.FloppyConfig.FloppyDirectories,
@@ -123,10 +127,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		&vmwcommon.StepSuppressMessages{},
 		&vmwcommon.StepHTTPIPDiscover{},
 		commonsteps.HTTPServerFromHTTPConfig(&b.config.HTTPConfig),
-		multistep.If(b.config.Comm.Type == "ssh", &communicator.StepSSHKeyGen{
-			CommConf:            &b.config.Comm,
-			SSHTemporaryKeyPair: b.config.Comm.SSHTemporaryKeyPair,
-		}),
 		&vmwcommon.StepConfigureVNC{
 			Enabled:            !b.config.DisableVNC && !b.config.VNCOverWebsocket,
 			VNCBindAddress:     b.config.VNCBindAddress,

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -71,6 +71,10 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			RemoteType:   b.config.RemoteType,
 			VMName:       b.config.VMName,
 		},
+		multistep.If(b.config.Comm.Type == "ssh", &communicator.StepSSHKeyGen{
+			CommConf:            &b.config.Comm,
+			SSHTemporaryKeyPair: b.config.Comm.SSHTemporaryKeyPair,
+		}),
 		&commonsteps.StepCreateFloppy{
 			Files:       b.config.FloppyConfig.FloppyFiles,
 			Directories: b.config.FloppyConfig.FloppyDirectories,
@@ -114,10 +118,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		&vmwcommon.StepSuppressMessages{},
 		&vmwcommon.StepHTTPIPDiscover{},
 		commonsteps.HTTPServerFromHTTPConfig(&b.config.HTTPConfig),
-		multistep.If(b.config.Comm.Type == "ssh", &communicator.StepSSHKeyGen{
-			CommConf:            &b.config.Comm,
-			SSHTemporaryKeyPair: b.config.Comm.SSHTemporaryKeyPair,
-		}),
 		&vmwcommon.StepUploadVMX{
 			RemoteType: b.config.RemoteType,
 		},


### PR DESCRIPTION
### Description

Moves `&communicator.StepSSHKeyGen` position to earlier in each builder.

### Testing

```shell
packer-plugin-vmware on  fix/update-stepsshkeygen-postion
✦ ➜ go fmt ./...

packer-plugin-vmware on  fix/update-stepsshkeygen-postion
✦ ➜ make generate
2024/06/25 20:07:52 Copying "docs" to ".docs/"
2024/06/25 20:07:52 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vmware on  fix/update-stepsshkeygen-postion
✦ ➜ make build

packer-plugin-vmware on  fix/update-stepsshkeygen-postion
✦ ➜ make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 7.279s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    3.271s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    4.406s
```

### Reference

Closes #177