### PR TITLE
docs: correct brand name

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -722,8 +722,8 @@ provisioner](/packer/docs/provisioner/file).
   need to connect to the console to debug the build process.
   Some users have experienced issues where Packer cannot properly connect
   to a VM if it is headless; this appears to be a result of not ever having
-  launched the VMWare GUI and accepting the evaluation license, or
-  supplying a real license. If you experience this, launching VMWare and
+  launched the VMware GUI and accepting the evaluation license, or
+  supplying a real license. If you experience this, launching VMware and
   accepting the license should resolve your problem.
 
 - `vnc_bind_address` (string) - The IP address that should be
@@ -773,7 +773,7 @@ provisioner](/packer/docs/provisioner/file).
 
 - `tools_source_path` (string) - The path on your local machine to fetch the vmware tools from. If this
   is not set but the tools_upload_flavor is set, then Packer will try to
-  load the VMWare tools from the VMWare installation directory.
+  load the VMware tools from the VMware installation directory.
 
 <!-- End of code generated from the comments of the ToolsConfig struct in builder/vmware/common/tools_config.go; -->
 
@@ -1278,7 +1278,7 @@ variables isn't required, however.
 - `GuestOS` - The VMware-valid guest OS type.
 - `DiskName` - The filename (without the suffix) of the main virtual disk.
 - `ISOPath` - The path to the ISO to use for the OS installation.
-- `Version` - The Hardware version VMWare will execute this vm under. Also
+- `Version` - The Hardware version VMware will execute this vm under. Also
   known as the `virtualhw.version`.
 
 ## Building on a Remote vSphere Hypervisor

--- a/.web-docs/components/builder/vmx/README.md
+++ b/.web-docs/components/builder/vmx/README.md
@@ -472,8 +472,8 @@ boot time.
   need to connect to the console to debug the build process.
   Some users have experienced issues where Packer cannot properly connect
   to a VM if it is headless; this appears to be a result of not ever having
-  launched the VMWare GUI and accepting the evaluation license, or
-  supplying a real license. If you experience this, launching VMWare and
+  launched the VMware GUI and accepting the evaluation license, or
+  supplying a real license. If you experience this, launching VMware and
   accepting the license should resolve your problem.
 
 - `vnc_bind_address` (string) - The IP address that should be
@@ -571,7 +571,7 @@ boot time.
 
 - `tools_source_path` (string) - The path on your local machine to fetch the vmware tools from. If this
   is not set but the tools_upload_flavor is set, then Packer will try to
-  load the VMWare tools from the VMWare installation directory.
+  load the VMware tools from the VMware installation directory.
 
 <!-- End of code generated from the comments of the ToolsConfig struct in builder/vmware/common/tools_config.go; -->
 

--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -384,7 +384,7 @@ func (d *VmwareDriver) PotentialGuestIP(state multistep.StateBag) ([]string, err
 
 			// First check for leases that are still valid. The timestamp for
 			// each lease should be in UTC according to the documentation at
-			// the top of VMWare's dhcpd.leases file.
+			// the top of VMware's dhcpd.leases file.
 			now := time.Now().UTC()
 			if !(now.After(entry.starts) && now.Before(entry.ends)) {
 				continue
@@ -434,7 +434,7 @@ func (d *VmwareDriver) PotentialGuestIP(state multistep.StateBag) ([]string, err
 
 	if runtime.GOOS == "darwin" {
 		// We have match no vmware DHCP lease for this MAC. We'll try to match it in Apple DHCP leases.
-		// As a remember, VMWare is no longer able to rely on its own dhcpd server on MacOS BigSur and is
+		// As a remember, VMware is no longer able to rely on its own dhcpd server on MacOS BigSur and is
 		// forced to use Apple DHCPD server instead.
 		// https://communities.vmware.com/t5/VMware-Fusion-Discussions/Big-Sur-hosts-with-Fusion-Is-vmnet-dhcpd-vmnet8-leases-file/m-p/2298927/highlight/true#M140003
 

--- a/builder/vmware/common/driver_player_unix.go
+++ b/builder/vmware/common/driver_player_unix.go
@@ -65,7 +65,7 @@ func playerDhcpLeasesPath(device string) string {
 		}
 	}
 
-	log.Printf("Error finding VMWare DHCP Server Leases (dhcpd.leases) under device path: %s", devicebase)
+	log.Printf("Error finding VMware DHCP Server Leases (dhcpd.leases) under device path: %s", devicebase)
 	return ""
 }
 
@@ -91,7 +91,7 @@ func playerVmDhcpConfPath(device string) string {
 		}
 	}
 
-	log.Printf("Error finding VMWare DHCP Server Configuration (dhcp.conf) under device path: %s", devicebase)
+	log.Printf("Error finding VMware DHCP Server Configuration (dhcp.conf) under device path: %s", devicebase)
 	return ""
 }
 
@@ -134,7 +134,7 @@ func playerVerifyVersion(version string) error {
 	if matches == nil {
 		return fmt.Errorf("error parsing version output: %s", stderr.String())
 	}
-	log.Printf("Detected VMWare Player version: %s", matches[1])
+	log.Printf("Detected VMware Player version: %s", matches[1])
 
 	return compareVersions(matches[1], version, "Player")
 }

--- a/builder/vmware/common/driver_workstation_unix.go
+++ b/builder/vmware/common/driver_workstation_unix.go
@@ -71,7 +71,7 @@ func workstationDhcpLeasesPath(device string) string {
 		}
 	}
 
-	log.Printf("Error finding VMWare DHCP Server Leases (dhcpd.leases) under device path: %s", devicebase)
+	log.Printf("Error finding VMware DHCP Server Leases (dhcpd.leases) under device path: %s", devicebase)
 	return ""
 }
 
@@ -97,7 +97,7 @@ func workstationDhcpConfPath(device string) string {
 		}
 	}
 
-	log.Printf("Error finding VMWare DHCP Server Configuration (dhcp.conf) under device path: %s", devicebase)
+	log.Printf("Error finding VMware DHCP Server Configuration (dhcp.conf) under device path: %s", devicebase)
 	return ""
 }
 

--- a/builder/vmware/common/hw_config.go
+++ b/builder/vmware/common/hw_config.go
@@ -141,7 +141,6 @@ func (c *HWConfig) Prepare(ctx *interpolate.Context) []error {
 	return errs
 }
 
-/* parallel port */
 type ParallelUnion struct {
 	Union  interface{}
 	File   *ParallelPortFile

--- a/builder/vmware/common/run_config.go
+++ b/builder/vmware/common/run_config.go
@@ -20,8 +20,8 @@ type RunConfig struct {
 	// need to connect to the console to debug the build process.
 	// Some users have experienced issues where Packer cannot properly connect
 	// to a VM if it is headless; this appears to be a result of not ever having
-	// launched the VMWare GUI and accepting the evaluation license, or
-	// supplying a real license. If you experience this, launching VMWare and
+	// launched the VMware GUI and accepting the evaluation license, or
+	// supplying a real license. If you experience this, launching VMware and
 	// accepting the license should resolve your problem.
 	Headless bool `mapstructure:"headless" required:"false"`
 	// The IP address that should be

--- a/builder/vmware/common/step_configure_vmx.go
+++ b/builder/vmware/common/step_configure_vmx.go
@@ -120,9 +120,9 @@ func (s *StepConfigureVMX) Run(ctx context.Context, state multistep.StateBag) mu
 	}
 
 	// Set the extendedConfigFile setting for the .vmxf filename to the VMName
-	// if displayName is not set. This is needed so that when VMWare creates
+	// if displayName is not set. This is needed so that when VMware creates
 	// the .vmxf file it matches the displayName if it is set. When just using
-	// the sisplayName if it was empty VMWare would make a file named ".vmxf".
+	// the sisplayName if it was empty VMware would make a file named ".vmxf".
 	// The ".vmxf" file would not get deleted when the VM got deleted.
 	if s.DisplayName != "" {
 		vmxData["extendedconfigfile"] = fmt.Sprintf("%s.vmxf", s.DisplayName)

--- a/builder/vmware/common/step_shutdown.go
+++ b/builder/vmware/common/step_shutdown.go
@@ -122,8 +122,8 @@ LockWaitLoop:
 	if !s.Testing {
 		// Windows takes a while to yield control of the files when the
 		// process is exiting. Ubuntu and OS X will yield control of the files
-		// but VMWare may overwrite the VMX cleanup steps that run after this,
-		// so we wait to ensure VMWare has exited and flushed the VMX.
+		// but VMware may overwrite the VMX cleanup steps that run after this,
+		// so we wait to ensure VMware has exited and flushed the VMX.
 
 		// We just sleep here. In the future, it'd be nice to find a better
 		// solution to this.

--- a/builder/vmware/common/tools_config.go
+++ b/builder/vmware/common/tools_config.go
@@ -25,7 +25,7 @@ type ToolsConfig struct {
 	ToolsUploadPath string `mapstructure:"tools_upload_path" required:"false"`
 	// The path on your local machine to fetch the vmware tools from. If this
 	// is not set but the tools_upload_flavor is set, then Packer will try to
-	// load the VMWare tools from the VMWare installation directory.
+	// load the VMware tools from the VMware installation directory.
 	ToolsSourcePath string `mapstructure:"tools_source_path" required:"false"`
 }
 

--- a/builder/vmware/vmx/config.go
+++ b/builder/vmware/vmx/config.go
@@ -20,7 +20,6 @@ import (
 	vmwcommon "github.com/hashicorp/packer-plugin-vmware/builder/vmware/common"
 )
 
-// Config is the configuration structure for the builder.
 type Config struct {
 	common.PackerConfig            `mapstructure:",squash"`
 	commonsteps.HTTPConfig         `mapstructure:",squash"`

--- a/docs-partials/builder/vmware/common/ParallelUnion.mdx
+++ b/docs-partials/builder/vmware/common/ParallelUnion.mdx
@@ -1,5 +1,0 @@
-<!-- Code generated from the comments of the ParallelUnion struct in builder/vmware/common/hw_config.go; DO NOT EDIT MANUALLY -->
-
-parallel port
-
-<!-- End of code generated from the comments of the ParallelUnion struct in builder/vmware/common/hw_config.go; -->

--- a/docs-partials/builder/vmware/common/RunConfig-not-required.mdx
+++ b/docs-partials/builder/vmware/common/RunConfig-not-required.mdx
@@ -7,8 +7,8 @@
   need to connect to the console to debug the build process.
   Some users have experienced issues where Packer cannot properly connect
   to a VM if it is headless; this appears to be a result of not ever having
-  launched the VMWare GUI and accepting the evaluation license, or
-  supplying a real license. If you experience this, launching VMWare and
+  launched the VMware GUI and accepting the evaluation license, or
+  supplying a real license. If you experience this, launching VMware and
   accepting the license should resolve your problem.
 
 - `vnc_bind_address` (string) - The IP address that should be

--- a/docs-partials/builder/vmware/common/SerialConfigPipe.mdx
+++ b/docs-partials/builder/vmware/common/SerialConfigPipe.mdx
@@ -1,5 +1,0 @@
-<!-- Code generated from the comments of the SerialConfigPipe struct in builder/vmware/common/hw_config.go; DO NOT EDIT MANUALLY -->
-
-serial conversions
-
-<!-- End of code generated from the comments of the SerialConfigPipe struct in builder/vmware/common/hw_config.go; -->

--- a/docs-partials/builder/vmware/common/ToolsConfig-not-required.mdx
+++ b/docs-partials/builder/vmware/common/ToolsConfig-not-required.mdx
@@ -13,6 +13,6 @@
 
 - `tools_source_path` (string) - The path on your local machine to fetch the vmware tools from. If this
   is not set but the tools_upload_flavor is set, then Packer will try to
-  load the VMWare tools from the VMWare installation directory.
+  load the VMware tools from the VMware installation directory.
 
 <!-- End of code generated from the comments of the ToolsConfig struct in builder/vmware/common/tools_config.go; -->

--- a/docs-partials/builder/vmware/vmx/Config.mdx
+++ b/docs-partials/builder/vmware/vmx/Config.mdx
@@ -1,5 +1,0 @@
-<!-- Code generated from the comments of the Config struct in builder/vmware/vmx/config.go; DO NOT EDIT MANUALLY -->
-
-Config is the configuration structure for the builder.
-
-<!-- End of code generated from the comments of the Config struct in builder/vmware/vmx/config.go; -->

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -239,7 +239,7 @@ variables isn't required, however.
 - `GuestOS` - The VMware-valid guest OS type.
 - `DiskName` - The filename (without the suffix) of the main virtual disk.
 - `ISOPath` - The path to the ISO to use for the OS installation.
-- `Version` - The Hardware version VMWare will execute this vm under. Also
+- `Version` - The Hardware version VMware will execute this vm under. Also
   known as the `virtualhw.version`.
 
 ## Building on a Remote vSphere Hypervisor


### PR DESCRIPTION
### Description

Updates "VMWare" to "VMware".

### Testing

```shell
packer-plugin-vmware on  docs/correct-brand-name
➜ go fmt ./...

packer-plugin-vmware on  docs/correct-brand-name
➜ make generate
2024/06/25 22:50:36 Copying "docs" to ".docs/"
2024/06/25 22:50:36 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vmware on  docs/correct-brand-name
➜ make build

packer-plugin-vmware on  docs/correct-brand-name
➜ make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 6.600s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    2.283s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    1.841s
```