### PR TITLE
chore: update virtual harware versions

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -78,47 +78,44 @@ necessary for this build to succeed and can be found further down the page.
 
 <!-- Code generated from the comments of the Config struct in builder/vmware/iso/config.go; DO NOT EDIT MANUALLY -->
 
-- `disk_size` (uint) - The size of the hard disk for the VM in megabytes.
-  The builder uses expandable, not fixed-size virtual hard disks, so the
-  actual file representing the disk will not use the full size unless it
-  is full. By default this is set to 40000 (about 40 GB).
+- `disk_size` (uint) - The size of the disk in megabytes. The builder uses expandable virtual
+  hard disks. The file that backs the virtual disk will only grow as needed
+  up to this size. Default is 40000 (~40 GB).
 
-- `cdrom_adapter_type` (string) - The adapter type (or bus) that will be used
-  by the cdrom device. This is chosen by default based on the disk adapter
-  type. VMware tends to lean towards ide for the cdrom device unless
-  sata is chosen for the disk adapter and so Packer attempts to mirror
-  this logic. This field can be specified as either ide, sata, or scsi.
+- `cdrom_adapter_type` (string) - The type of controller to use for the CD-ROM device.
+  Allowed values are `ide`, `sata`, and `scsi`.
 
-- `guest_os_type` (string) - The guest OS type being installed. This will be
-  set in the VMware VMX. By default this is other. By specifying a more
-  specific OS type, VMware may perform some optimizations or virtual hardware
-  changes to better support the operating system running in the
-  virtual machine. Valid values differ by platform and version numbers, and may
-  not match other VMware API's representation of the guest OS names. Consult your
-  platform for valid values.
+- `guest_os_type` (string) - The guest operating system identifier for the virtual machine.
+  Defaults to `other`.
 
-- `version` (string) - The [vmx hardware
-  version](http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1003746)
-  for the new virtual machine. Only the default value has been tested, any
-  other value is experimental. Default value is `9`.
+- `version` (int) - The virtual machine hardware version. Refer to [KB 315655](https://knowledge.broadcom.com/external/article?articleNumber=315655)
+  for more information on supported virtual hardware versions.
+  Minimum is 13. Default is 19.
 
-- `vm_name` (string) - This is the name of the VMX file for the new virtual
-  machine, without the file extension. By default this is packer-BUILDNAME,
-  where "BUILDNAME" is the name of the build.
+- `vm_name` (string) - The name of the virtual machine. This represents the name of the virtual
+  machine `.vmx` configuration file without the file extension.
+  Default is `packer-<BUILDNAME>`, where `<BUILDNAME>` is the name of the
+  build.
 
-- `vmx_disk_template_path` (string) - VMX Disk Template Path
-
-- `vmx_template_path` (string) - Path to a [configuration template](/packer/docs/templates/legacy_json_templates/engine) that
-  defines the contents of the virtual machine VMX file for VMware. The
-  engine has access to the template variables `{{ .DiskNumber }}` and
-  `{{ .DiskName }}`.
+- `vmx_disk_template_path` (string) - The path to a [configuration template](/packer/docs/templates/legacy_json_templates/engine)
+  for defining the contents of a virtual machine `.vmx` configuration file
+  for a virtual disk. Template variables `{{ .DiskType }}`, `{{ .DiskUnit }}`,
+  `{{ .DiskName }}`, and `{{ .DiskNumber }}` are available for use within
+  the template.
   
-  This is for **advanced users only** as this can render the virtual machine
-  non-functional. See below for more information. For basic VMX
-  modifications, try `vmx_data` first.
+  ~> **Note:** This option is intended for advanced users, as incorrect
+  configurations can lead to non-functional virtual machines.
 
-- `snapshot_name` (string) - This is the name of the initial snapshot created after provisioning and cleanup.
-  if left blank, no initial snapshot will be created
+- `vmx_template_path` (string) - The path to a [configuration template](/packer/docs/templates/legacy_json_templates/engine)
+  for defining the contents of a virtual machine `.vmx` configuration file.
+  
+  ~> **Note:** This option is intended for advanced users, as incorrect
+  configurations can lead to non-functional virtual machines. For simpler
+  modifications of the virtual machine`.vmx` configuration file, consider
+  using `vmx_data` option.
+
+- `snapshot_name` (string) - The name of the virtual machine snapshot to be created.
+  If this field is left empty, no snapshot will be created.
 
 <!-- End of code generated from the comments of the Config struct in builder/vmware/iso/config.go; -->
 

--- a/builder/vmware/iso/builder_test.go
+++ b/builder/vmware/iso/builder_test.go
@@ -15,6 +15,7 @@ import (
 
 func testConfig() map[string]interface{} {
 	return map[string]interface{}{
+		"version":          21,
 		"iso_checksum":     "md5:0B0F137F17AC10944716020B018F8126",
 		"iso_url":          "http://www.packer.io",
 		"shutdown_command": "foo",
@@ -47,8 +48,8 @@ func TestBuilderPrepare_Defaults(t *testing.T) {
 		t.Errorf("bad output dir: %s", b.config.OutputDir)
 	}
 
-	if b.config.Version != "9" {
-		t.Errorf("bad Version: %s", b.config.Version)
+	if b.config.Version < minimumHardwareVersion {
+		t.Errorf("bad version: %d, minimum hardware version: %d", b.config.Version, minimumHardwareVersion)
 	}
 
 	if b.config.VMName != "packer-foo" {
@@ -308,7 +309,7 @@ func TestBuilderPrepare_Export(t *testing.T) {
 				outCfg.Format, tc.Reason)
 		}
 		if outCfg.SkipExport != tc.ExpectedSkipExportValue {
-			t.Fatalf("For SkipExport expected %t but recieved %t",
+			t.Fatalf("For SkipExport expected %t but received %t",
 				tc.ExpectedSkipExportValue, outCfg.SkipExport)
 		}
 	}

--- a/builder/vmware/iso/config.go
+++ b/builder/vmware/iso/config.go
@@ -15,12 +15,17 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/bootcommand"
 	"github.com/hashicorp/packer-plugin-sdk/common"
 	"github.com/hashicorp/packer-plugin-sdk/multistep/commonsteps"
+	"github.com/hashicorp/packer-plugin-sdk/packer"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/shutdowncommand"
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 	vmwcommon "github.com/hashicorp/packer-plugin-vmware/builder/vmware/common"
 )
+
+// Reference: https://knowledge.broadcom.com/external/article?articleNumber=315655
+const minimumHardwareVersion = 13
+const defaultHardwareVersion = 19
 
 type Config struct {
 	common.PackerConfig            `mapstructure:",squash"`
@@ -39,47 +44,44 @@ type Config struct {
 	vmwcommon.VMXConfig            `mapstructure:",squash"`
 	vmwcommon.ExportConfig         `mapstructure:",squash"`
 	vmwcommon.DiskConfig           `mapstructure:",squash"`
-	// The size of the hard disk for the VM in megabytes.
-	// The builder uses expandable, not fixed-size virtual hard disks, so the
-	// actual file representing the disk will not use the full size unless it
-	// is full. By default this is set to 40000 (about 40 GB).
+	// The size of the disk in megabytes. The builder uses expandable virtual
+	// hard disks. The file that backs the virtual disk will only grow as needed
+	// up to this size. Default is 40000 (~40 GB).
 	DiskSize uint `mapstructure:"disk_size" required:"false"`
-	// The adapter type (or bus) that will be used
-	// by the cdrom device. This is chosen by default based on the disk adapter
-	// type. VMware tends to lean towards ide for the cdrom device unless
-	// sata is chosen for the disk adapter and so Packer attempts to mirror
-	// this logic. This field can be specified as either ide, sata, or scsi.
+	// The type of controller to use for the CD-ROM device.
+	// Allowed values are `ide`, `sata`, and `scsi`.
 	CdromAdapterType string `mapstructure:"cdrom_adapter_type" required:"false"`
-	// The guest OS type being installed. This will be
-	// set in the VMware VMX. By default this is other. By specifying a more
-	// specific OS type, VMware may perform some optimizations or virtual hardware
-	// changes to better support the operating system running in the
-	// virtual machine. Valid values differ by platform and version numbers, and may
-	// not match other VMware API's representation of the guest OS names. Consult your
-	// platform for valid values.
+	// The guest operating system identifier for the virtual machine.
+	// Defaults to `other`.
 	GuestOSType string `mapstructure:"guest_os_type" required:"false"`
-	// The [vmx hardware
-	// version](http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1003746)
-	// for the new virtual machine. Only the default value has been tested, any
-	// other value is experimental. Default value is `9`.
-	Version string `mapstructure:"version" required:"false"`
-	// This is the name of the VMX file for the new virtual
-	// machine, without the file extension. By default this is packer-BUILDNAME,
-	// where "BUILDNAME" is the name of the build.
+	// The virtual machine hardware version. Refer to [KB 315655](https://knowledge.broadcom.com/external/article?articleNumber=315655)
+	// for more information on supported virtual hardware versions.
+	// Minimum is 13. Default is 19.
+	Version int `mapstructure:"version" required:"false"`
+	// The name of the virtual machine. This represents the name of the virtual
+	// machine `.vmx` configuration file without the file extension.
+	// Default is `packer-<BUILDNAME>`, where `<BUILDNAME>` is the name of the
+	// build.
 	VMName string `mapstructure:"vm_name" required:"false"`
-
-	VMXDiskTemplatePath string `mapstructure:"vmx_disk_template_path"`
-	// Path to a [configuration template](/packer/docs/templates/legacy_json_templates/engine) that
-	// defines the contents of the virtual machine VMX file for VMware. The
-	// engine has access to the template variables `{{ .DiskNumber }}` and
-	// `{{ .DiskName }}`.
+	// The path to a [configuration template](/packer/docs/templates/legacy_json_templates/engine)
+	// for defining the contents of a virtual machine `.vmx` configuration file
+	// for a virtual disk. Template variables `{{ .DiskType }}`, `{{ .DiskUnit }}`,
+	// `{{ .DiskName }}`, and `{{ .DiskNumber }}` are available for use within
+	// the template.
 	//
-	// This is for **advanced users only** as this can render the virtual machine
-	// non-functional. See below for more information. For basic VMX
-	// modifications, try `vmx_data` first.
+	// ~> **Note:** This option is intended for advanced users, as incorrect
+	// configurations can lead to non-functional virtual machines.
+	VMXDiskTemplatePath string `mapstructure:"vmx_disk_template_path"`
+	// The path to a [configuration template](/packer/docs/templates/legacy_json_templates/engine)
+	// for defining the contents of a virtual machine `.vmx` configuration file.
+	//
+	// ~> **Note:** This option is intended for advanced users, as incorrect
+	// configurations can lead to non-functional virtual machines. For simpler
+	// modifications of the virtual machine`.vmx` configuration file, consider
+	// using `vmx_data` option.
 	VMXTemplatePath string `mapstructure:"vmx_template_path" required:"false"`
-	// This is the name of the initial snapshot created after provisioning and cleanup.
-	// if left blank, no initial snapshot will be created
+	// The name of the virtual machine snapshot to be created.
+	// If this field is left empty, no snapshot will be created.
 	SnapshotName string `mapstructure:"snapshot_name" required:"false"`
 
 	ctx interpolate.Context
@@ -153,8 +155,10 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		c.VMName = fmt.Sprintf("packer-%s", c.PackerBuildName)
 	}
 
-	if c.Version == "" {
-		c.Version = "9"
+	if c.Version == 0 {
+		c.Version = defaultHardwareVersion
+	} else if c.Version < minimumHardwareVersion {
+		errs = packer.MultiErrorAppend(errs, fmt.Errorf("invalid 'version' %d, minimum hardware version: %d", c.Version, minimumHardwareVersion))
 	}
 
 	if c.VMXTemplatePath != "" {

--- a/builder/vmware/iso/config.hcl2spec.go
+++ b/builder/vmware/iso/config.hcl2spec.go
@@ -143,7 +143,7 @@ type FlatConfig struct {
 	DiskSize                  *uint             `mapstructure:"disk_size" required:"false" cty:"disk_size" hcl:"disk_size"`
 	CdromAdapterType          *string           `mapstructure:"cdrom_adapter_type" required:"false" cty:"cdrom_adapter_type" hcl:"cdrom_adapter_type"`
 	GuestOSType               *string           `mapstructure:"guest_os_type" required:"false" cty:"guest_os_type" hcl:"guest_os_type"`
-	Version                   *string           `mapstructure:"version" required:"false" cty:"version" hcl:"version"`
+	Version                   *int              `mapstructure:"version" required:"false" cty:"version" hcl:"version"`
 	VMName                    *string           `mapstructure:"vm_name" required:"false" cty:"vm_name" hcl:"vm_name"`
 	VMXDiskTemplatePath       *string           `mapstructure:"vmx_disk_template_path" cty:"vmx_disk_template_path" hcl:"vmx_disk_template_path"`
 	VMXTemplatePath           *string           `mapstructure:"vmx_template_path" required:"false" cty:"vmx_template_path" hcl:"vmx_template_path"`
@@ -295,7 +295,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disk_size":                      &hcldec.AttrSpec{Name: "disk_size", Type: cty.Number, Required: false},
 		"cdrom_adapter_type":             &hcldec.AttrSpec{Name: "cdrom_adapter_type", Type: cty.String, Required: false},
 		"guest_os_type":                  &hcldec.AttrSpec{Name: "guest_os_type", Type: cty.String, Required: false},
-		"version":                        &hcldec.AttrSpec{Name: "version", Type: cty.String, Required: false},
+		"version":                        &hcldec.AttrSpec{Name: "version", Type: cty.Number, Required: false},
 		"vm_name":                        &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"vmx_disk_template_path":         &hcldec.AttrSpec{Name: "vmx_disk_template_path", Type: cty.String, Required: false},
 		"vmx_template_path":              &hcldec.AttrSpec{Name: "vmx_template_path", Type: cty.String, Required: false},

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -25,6 +25,7 @@ type vmxTemplateData struct {
 	ISOPath string
 	Version string
 
+	SecureBoot string
 	CpuCount   string
 	MemorySize string
 
@@ -142,7 +143,7 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 
 				rawBytes, err := io.ReadAll(f)
 				if err != nil {
-					err := fmt.Errorf("rrror reading VMX disk template: %s", err)
+					err := fmt.Errorf("error reading VMX disk template: %s", err)
 					state.Put("error", err)
 					ui.Error(err.Error())
 					return multistep.ActionHalt
@@ -164,12 +165,11 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 	}
 
 	templateData := vmxTemplateData{
-		Name:     config.VMName,
-		GuestOS:  config.GuestOSType,
-		DiskName: config.DiskName,
-		Version:  config.Version,
-		ISOPath:  isoPath,
-
+		Name:            config.VMName,
+		GuestOS:         config.GuestOSType,
+		DiskName:        config.DiskName,
+		Version:         strconv.Itoa(config.Version),
+		ISOPath:         isoPath,
 		Network_Adapter: "e1000",
 
 		Sound_Present: map[bool]string{true: "TRUE", false: "FALSE"}[config.HWConfig.Sound],

--- a/docs-partials/builder/vmware/iso/Config-not-required.mdx
+++ b/docs-partials/builder/vmware/iso/Config-not-required.mdx
@@ -1,45 +1,42 @@
 <!-- Code generated from the comments of the Config struct in builder/vmware/iso/config.go; DO NOT EDIT MANUALLY -->
 
-- `disk_size` (uint) - The size of the hard disk for the VM in megabytes.
-  The builder uses expandable, not fixed-size virtual hard disks, so the
-  actual file representing the disk will not use the full size unless it
-  is full. By default this is set to 40000 (about 40 GB).
+- `disk_size` (uint) - The size of the disk in megabytes. The builder uses expandable virtual
+  hard disks. The file that backs the virtual disk will only grow as needed
+  up to this size. Default is 40000 (~40 GB).
 
-- `cdrom_adapter_type` (string) - The adapter type (or bus) that will be used
-  by the cdrom device. This is chosen by default based on the disk adapter
-  type. VMware tends to lean towards ide for the cdrom device unless
-  sata is chosen for the disk adapter and so Packer attempts to mirror
-  this logic. This field can be specified as either ide, sata, or scsi.
+- `cdrom_adapter_type` (string) - The type of controller to use for the CD-ROM device.
+  Allowed values are `ide`, `sata`, and `scsi`.
 
-- `guest_os_type` (string) - The guest OS type being installed. This will be
-  set in the VMware VMX. By default this is other. By specifying a more
-  specific OS type, VMware may perform some optimizations or virtual hardware
-  changes to better support the operating system running in the
-  virtual machine. Valid values differ by platform and version numbers, and may
-  not match other VMware API's representation of the guest OS names. Consult your
-  platform for valid values.
+- `guest_os_type` (string) - The guest operating system identifier for the virtual machine.
+  Defaults to `other`.
 
-- `version` (string) - The [vmx hardware
-  version](http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1003746)
-  for the new virtual machine. Only the default value has been tested, any
-  other value is experimental. Default value is `9`.
+- `version` (int) - The virtual machine hardware version. Refer to [KB 315655](https://knowledge.broadcom.com/external/article?articleNumber=315655)
+  for more information on supported virtual hardware versions.
+  Minimum is 13. Default is 19.
 
-- `vm_name` (string) - This is the name of the VMX file for the new virtual
-  machine, without the file extension. By default this is packer-BUILDNAME,
-  where "BUILDNAME" is the name of the build.
+- `vm_name` (string) - The name of the virtual machine. This represents the name of the virtual
+  machine `.vmx` configuration file without the file extension.
+  Default is `packer-<BUILDNAME>`, where `<BUILDNAME>` is the name of the
+  build.
 
-- `vmx_disk_template_path` (string) - VMX Disk Template Path
-
-- `vmx_template_path` (string) - Path to a [configuration template](/packer/docs/templates/legacy_json_templates/engine) that
-  defines the contents of the virtual machine VMX file for VMware. The
-  engine has access to the template variables `{{ .DiskNumber }}` and
-  `{{ .DiskName }}`.
+- `vmx_disk_template_path` (string) - The path to a [configuration template](/packer/docs/templates/legacy_json_templates/engine)
+  for defining the contents of a virtual machine `.vmx` configuration file
+  for a virtual disk. Template variables `{{ .DiskType }}`, `{{ .DiskUnit }}`,
+  `{{ .DiskName }}`, and `{{ .DiskNumber }}` are available for use within
+  the template.
   
-  This is for **advanced users only** as this can render the virtual machine
-  non-functional. See below for more information. For basic VMX
-  modifications, try `vmx_data` first.
+  ~> **Note:** This option is intended for advanced users, as incorrect
+  configurations can lead to non-functional virtual machines.
 
-- `snapshot_name` (string) - This is the name of the initial snapshot created after provisioning and cleanup.
-  if left blank, no initial snapshot will be created
+- `vmx_template_path` (string) - The path to a [configuration template](/packer/docs/templates/legacy_json_templates/engine)
+  for defining the contents of a virtual machine `.vmx` configuration file.
+  
+  ~> **Note:** This option is intended for advanced users, as incorrect
+  configurations can lead to non-functional virtual machines. For simpler
+  modifications of the virtual machine`.vmx` configuration file, consider
+  using `vmx_data` option.
+
+- `snapshot_name` (string) - The name of the virtual machine snapshot to be created.
+  If this field is left empty, no snapshot will be created.
 
 <!-- End of code generated from the comments of the Config struct in builder/vmware/iso/config.go; -->


### PR DESCRIPTION
### Description

- Updates `version` to an `int` instead of a string.
- Adds a check in `Prepare()` to ensure the value is > the minimum.
- - Updates the documentation in `config.go`.
- Adds constants for the minimum and default virtual hardware versions.

> [!IMPORTANT]  
> - Minimum is now 13 instead of 9.
> - Default is 19 instead of 9.

### Testing

```console
packer-plugin-vmware on  chore/update-virtual-harware-versions
➜ go fmt ./... 

packer-plugin-vmware on  chore/update-virtual-harware-versions
➜ make generate
2024/06/30 14:52:08 Copying "docs" to ".docs/"
2024/06/30 14:52:08 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vmware on  chore/update-virtual-harware-versions
➜ make build   

packer-plugin-vmware on  chore/update-virtual-harware-versions
➜ make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 6.598s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    1.811s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    2.122s

packer-plugin-vmware on  chore/update-virtual-harware-versions
packer plugins install --path packer-plugin-vmware "github.com/hashicorp/vmware"
Successfully installed plugin github.com/hashicorp/vmware from /Users/ryan/Library/Mobile Documents/com~apple~CloudDocs/Code/Personal/packer-plugin-vmware/packer-plugin-vmware to /Users/ryan/.packer.d/plugins/github.com/hashicorp/vmware/packer-plugin-vmware_v1.0.12-dev_x5.0_darwin_arm64
```

Tested on:
- macOS 14.5 with VMware Fusion 13.5 (MacBook Pro M2 Max)
- Windows 11 22H2 with VMware Workstation 17.5 (Dell OptiPlex 7050 i7)

The virtual machines were able to boot with and without configuration of the `version`.

`.vmx` results for the default:

```text
virtualhw.productcompatibility = "hosted"
virtualhw.version = "19"
vmci0.id = "1861462627"
```

### Reference

- [Broadcom KB 315655](https://knowledge.broadcom.com/external/article?articleNumber=315655) 
