### PR TITLE
feat: add uefi and secure boot

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -572,53 +572,58 @@ provisioner](/packer/docs/provisioner/file).
 
 <!-- Code generated from the comments of the HWConfig struct in builder/vmware/common/hw_config.go; DO NOT EDIT MANUALLY -->
 
-- `cpus` (int) - The number of cpus to use when building the VM.
+- `firmware` (string) - The firmware type for the virtual machine.
+  Allowed values are `bios`, `efi`, and `efi-secure` (for secure boot).
+  Defaults to the recommended firmware type for the guest operating system.
 
-- `memory` (int) - The amount of memory to use when building the VM in megabytes.
+- `cpus` (int) - The number of virtual CPUs cores for the virtual machine.
 
-- `cores` (int) - The number of cores per socket to use when building the VM. This
-  corresponds to the cpuid.coresPerSocket option in the .vmx file.
+- `cores` (int) - The number of virtual CPU cores per socket for the virtual machine.
 
-- `network` (string) - This is the network type that the virtual machine will be created with.
-  This can be one of the generic values that map to a device such as
-  hostonly, nat, or bridged. If the network is not one of these values,
-  then it is assumed to be a VMware network device. (VMnet0..x)
+- `memory` (int) - The amount of memory for the virtual machine in MB.
 
-- `network_adapter_type` (string) - This is the ethernet adapter type the the virtual machine will be
-  created with. By default the `e1000` network adapter type will be used
-  by Packer. For more information, please consult [Choosing a network
-  adapter for your virtual
-  machine](https://kb.vmware.com/s/article/1001805) for desktop VMware
-  clients. For ESXi, refer to the proper ESXi documentation.
+- `network` (string) - The network which the virtual machine will connect for local desktop
+  hypervisors. Use the generic values that map to a device, such as
+  `hostonly`, `nat`, or `bridged`. Defaults to `nat`.
+  
+  ~> **Note:** If not set to one of these generic values, then it is
+  assumed to be a network device (_e.g._, `VMnet0..x`).
 
-- `network_name` (string) - The custom name of the network. Sets the vmx value "ethernet0.networkName"
+- `network_name` (string) - The network which the virtual machine will connect on a remote
+  hypervisor.
 
-- `sound` (bool) - Specify whether to enable VMware's virtual soundcard device when
-  building the VM. Defaults to false.
+- `network_adapter_type` (string) - The virtual machine network card type. Recommended values are `e1000` and
+  `vmxnet3`. Defaults to `e1000`.
+  
+  Refer to VMware product documentation for supported network adapter types
+  for the hypervisor and guest operating system.
 
-- `usb` (bool) - Enable VMware's USB bus when building the guest VM. Defaults to false.
-  To enable usage of the XHCI bus for USB 3 (5 Gbit/s), one can use the
-  vmx_data option to enable it by specifying true for the usb_xhci.present
-  property.
+- `sound` (bool) - Enable virtual sound card device. Defaults to `false`.
 
-- `serial` (string) - This specifies a serial port to add to the VM. It has a format of
-  `Type:option1,option2,...`. The field `Type` can be one of the following
-  values: `FILE`, `DEVICE`, `PIPE`, `AUTO`, or `NONE`.
+- `usb` (bool) - Enable a the USB 2.0 controllers for the virtual machine.
+  Defaults to `false`.
+  
+  ~> **Note:** To enable USB 3.0 controllers, set a `usb_xhci.present`
+  key to `true` in the `vmx_data` option.
+
+- `serial` (string) - Add a serial port to the virtual machine. Use a format of
+  `Type:option1,option2,...`. Allowed values for the field `Type` include:
+  `FILE`, `DEVICE`, `PIPE`, `AUTO`, or `NONE`.
   
   * `FILE:path(,yield)` - Specifies the path to the local file to be used
     as the serial port.
   
     * `yield` (bool) - This is an optional boolean that specifies
-      whether the vm should yield the cpu when polling the port. By
-      default, the builder will assume this as `FALSE`.
+      whether the virtual machine should yield the CPU when polling the
+      port. By default, the builder will assume this as `FALSE`.
   
   * `DEVICE:path(,yield)` - Specifies the path to the local device to be
      used as the serial port. If `path` is empty, then default to the first
     serial port.
   
     * `yield` (bool) - This is an optional boolean that specifies
-      whether the vm should yield the cpu when polling the port. By
-      default, the builder will assume this as `FALSE`.
+      whether the virtual machine should yield the CPU when polling the
+      port. By default, the builder will assume this as `FALSE`.
   
   * `PIPE:path,endpoint,host(,yield)` - Specifies to use the named-pipe
     "path" as a serial port. This has a few options that determine how the
@@ -627,38 +632,38 @@ provisioner](/packer/docs/provisioner/file).
     * `endpoint` (string) - Chooses the type of the VM-end, which can be
       either a `client` or `server`.
   
-    * `host` (string)     - Chooses the type of the host-end, which can
-      be either `app` (application) or `vm` (another virtual-machine).
+    * `host` (string) - Chooses the type of the host-end, which can be
+      either `app` (application) or `vm` (another virtual-machine).
   
-    * `yield` (bool)      - This is an optional boolean that specifies
-      whether the vm should yield the cpu when polling the port. By
+    * `yield` (bool) - This is an optional boolean that specifies whether
+      the virtual machine should yield the CPU when polling the port. By
       default, the builder will assume this as `FALSE`.
   
   * `AUTO:(yield)` - Specifies to use auto-detection to determine the
-    serial port to use. This has one option to determine how the VM should
-    support the serial port.
+    serial port to use. This has one option to determine how the virtual
+    machine should support the serial port.
   
-    * `yield` (bool) - This is an optional boolean that specifies
-      whether the vm should yield the cpu when polling the port. By
+    * `yield` (bool) - This is an optional boolean that specifies whether
+      the virtual machine should yield the CPU when polling the port. By
       default, the builder will assume this as `FALSE`.
   
   * `NONE` - Specifies to not use a serial port. (default)
 
-- `parallel` (string) - This specifies a parallel port to add to the VM. It has the format of
-  `Type:option1,option2,...`. Type can be one of the following values:
+- `parallel` (string) - Add a parallel port to add to the virtual machine. Use a format of
+  `Type:option1,option2,...`. Allowed values for the field `Type` include:
   `FILE`, `DEVICE`, `AUTO`, or `NONE`.
   
-  * `FILE:path` 		- Specifies the path to the local file to be used
-    for the parallel port.
+  * `FILE:path` - Specifies the path to the local file to be used for the
+     parallel port.
   
-  * `DEVICE:path`	 	- Specifies the path to the local device to be used
-    for the parallel port.
+  * `DEVICE:path` - Specifies the path to the local device to be used for
+     the parallel port.
   
-  * `AUTO:direction`   - Specifies to use auto-detection to determine the
+  * `AUTO:direction` - Specifies to use auto-detection to determine the
     parallel port. Direction can be `BI` to specify bidirectional
     communication or `UNI` to specify unidirectional communication.
   
-  * `NONE` 			- Specifies to not use a parallel port. (default)
+  * `NONE` - Specifies to not use a parallel port. (default)
 
 <!-- End of code generated from the comments of the HWConfig struct in builder/vmware/common/hw_config.go; -->
 

--- a/builder/vmware/iso/config.hcl2spec.go
+++ b/builder/vmware/iso/config.hcl2spec.go
@@ -53,12 +53,13 @@ type FlatConfig struct {
 	RemotePassword                 *string           `mapstructure:"remote_password" required:"false" cty:"remote_password" hcl:"remote_password"`
 	RemotePrivateKey               *string           `mapstructure:"remote_private_key_file" required:"false" cty:"remote_private_key_file" hcl:"remote_private_key_file"`
 	SkipValidateCredentials        *bool             `mapstructure:"skip_validate_credentials" required:"false" cty:"skip_validate_credentials" hcl:"skip_validate_credentials"`
+	Firmware                       *string           `mapstructure:"firmware" required:"false" cty:"firmware" hcl:"firmware"`
 	CpuCount                       *int              `mapstructure:"cpus" required:"false" cty:"cpus" hcl:"cpus"`
-	MemorySize                     *int              `mapstructure:"memory" required:"false" cty:"memory" hcl:"memory"`
 	CoreCount                      *int              `mapstructure:"cores" required:"false" cty:"cores" hcl:"cores"`
+	MemorySize                     *int              `mapstructure:"memory" required:"false" cty:"memory" hcl:"memory"`
 	Network                        *string           `mapstructure:"network" required:"false" cty:"network" hcl:"network"`
-	NetworkAdapterType             *string           `mapstructure:"network_adapter_type" required:"false" cty:"network_adapter_type" hcl:"network_adapter_type"`
 	NetworkName                    *string           `mapstructure:"network_name" required:"false" cty:"network_name" hcl:"network_name"`
+	NetworkAdapterType             *string           `mapstructure:"network_adapter_type" required:"false" cty:"network_adapter_type" hcl:"network_adapter_type"`
 	Sound                          *bool             `mapstructure:"sound" required:"false" cty:"sound" hcl:"sound"`
 	USB                            *bool             `mapstructure:"usb" required:"false" cty:"usb" hcl:"usb"`
 	Serial                         *string           `mapstructure:"serial" required:"false" cty:"serial" hcl:"serial"`
@@ -206,12 +207,13 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"remote_password":                &hcldec.AttrSpec{Name: "remote_password", Type: cty.String, Required: false},
 		"remote_private_key_file":        &hcldec.AttrSpec{Name: "remote_private_key_file", Type: cty.String, Required: false},
 		"skip_validate_credentials":      &hcldec.AttrSpec{Name: "skip_validate_credentials", Type: cty.Bool, Required: false},
+		"firmware":                       &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},
 		"cpus":                           &hcldec.AttrSpec{Name: "cpus", Type: cty.Number, Required: false},
-		"memory":                         &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
 		"cores":                          &hcldec.AttrSpec{Name: "cores", Type: cty.Number, Required: false},
+		"memory":                         &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
 		"network":                        &hcldec.AttrSpec{Name: "network", Type: cty.String, Required: false},
-		"network_adapter_type":           &hcldec.AttrSpec{Name: "network_adapter_type", Type: cty.String, Required: false},
 		"network_name":                   &hcldec.AttrSpec{Name: "network_name", Type: cty.String, Required: false},
+		"network_adapter_type":           &hcldec.AttrSpec{Name: "network_adapter_type", Type: cty.String, Required: false},
 		"sound":                          &hcldec.AttrSpec{Name: "sound", Type: cty.Bool, Required: false},
 		"usb":                            &hcldec.AttrSpec{Name: "usb", Type: cty.Bool, Required: false},
 		"serial":                         &hcldec.AttrSpec{Name: "serial", Type: cty.String, Required: false},

--- a/docs-partials/builder/vmware/common/HWConfig-not-required.mdx
+++ b/docs-partials/builder/vmware/common/HWConfig-not-required.mdx
@@ -1,52 +1,57 @@
 <!-- Code generated from the comments of the HWConfig struct in builder/vmware/common/hw_config.go; DO NOT EDIT MANUALLY -->
 
-- `cpus` (int) - The number of cpus to use when building the VM.
+- `firmware` (string) - The firmware type for the virtual machine.
+  Allowed values are `bios`, `efi`, and `efi-secure` (for secure boot).
+  Defaults to the recommended firmware type for the guest operating system.
 
-- `memory` (int) - The amount of memory to use when building the VM in megabytes.
+- `cpus` (int) - The number of virtual CPUs cores for the virtual machine.
 
-- `cores` (int) - The number of cores per socket to use when building the VM. This
-  corresponds to the cpuid.coresPerSocket option in the .vmx file.
+- `cores` (int) - The number of virtual CPU cores per socket for the virtual machine.
 
-- `network` (string) - This is the network type that the virtual machine will be created with.
-  This can be one of the generic values that map to a device such as
-  hostonly, nat, or bridged. If the network is not one of these values,
-  then it is assumed to be a VMware network device. (VMnet0..x)
+- `memory` (int) - The amount of memory for the virtual machine in MB.
 
-- `network_adapter_type` (string) - This is the ethernet adapter type the the virtual machine will be
-  created with. By default the `e1000` network adapter type will be used
-  by Packer. For more information, please consult [Choosing a network
-  adapter for your virtual
-  machine](https://kb.vmware.com/s/article/1001805) for desktop VMware
-  clients. For ESXi, refer to the proper ESXi documentation.
+- `network` (string) - The network which the virtual machine will connect for local desktop
+  hypervisors. Use the generic values that map to a device, such as
+  `hostonly`, `nat`, or `bridged`. Defaults to `nat`.
+  
+  ~> **Note:** If not set to one of these generic values, then it is
+  assumed to be a network device (_e.g._, `VMnet0..x`).
 
-- `network_name` (string) - The custom name of the network. Sets the vmx value "ethernet0.networkName"
+- `network_name` (string) - The network which the virtual machine will connect on a remote
+  hypervisor.
 
-- `sound` (bool) - Specify whether to enable VMware's virtual soundcard device when
-  building the VM. Defaults to false.
+- `network_adapter_type` (string) - The virtual machine network card type. Recommended values are `e1000` and
+  `vmxnet3`. Defaults to `e1000`.
+  
+  Refer to VMware product documentation for supported network adapter types
+  for the hypervisor and guest operating system.
 
-- `usb` (bool) - Enable VMware's USB bus when building the guest VM. Defaults to false.
-  To enable usage of the XHCI bus for USB 3 (5 Gbit/s), one can use the
-  vmx_data option to enable it by specifying true for the usb_xhci.present
-  property.
+- `sound` (bool) - Enable virtual sound card device. Defaults to `false`.
 
-- `serial` (string) - This specifies a serial port to add to the VM. It has a format of
-  `Type:option1,option2,...`. The field `Type` can be one of the following
-  values: `FILE`, `DEVICE`, `PIPE`, `AUTO`, or `NONE`.
+- `usb` (bool) - Enable a the USB 2.0 controllers for the virtual machine.
+  Defaults to `false`.
+  
+  ~> **Note:** To enable USB 3.0 controllers, set a `usb_xhci.present`
+  key to `true` in the `vmx_data` option.
+
+- `serial` (string) - Add a serial port to the virtual machine. Use a format of
+  `Type:option1,option2,...`. Allowed values for the field `Type` include:
+  `FILE`, `DEVICE`, `PIPE`, `AUTO`, or `NONE`.
   
   * `FILE:path(,yield)` - Specifies the path to the local file to be used
     as the serial port.
   
     * `yield` (bool) - This is an optional boolean that specifies
-      whether the vm should yield the cpu when polling the port. By
-      default, the builder will assume this as `FALSE`.
+      whether the virtual machine should yield the CPU when polling the
+      port. By default, the builder will assume this as `FALSE`.
   
   * `DEVICE:path(,yield)` - Specifies the path to the local device to be
      used as the serial port. If `path` is empty, then default to the first
     serial port.
   
     * `yield` (bool) - This is an optional boolean that specifies
-      whether the vm should yield the cpu when polling the port. By
-      default, the builder will assume this as `FALSE`.
+      whether the virtual machine should yield the CPU when polling the
+      port. By default, the builder will assume this as `FALSE`.
   
   * `PIPE:path,endpoint,host(,yield)` - Specifies to use the named-pipe
     "path" as a serial port. This has a few options that determine how the
@@ -55,37 +60,37 @@
     * `endpoint` (string) - Chooses the type of the VM-end, which can be
       either a `client` or `server`.
   
-    * `host` (string)     - Chooses the type of the host-end, which can
-      be either `app` (application) or `vm` (another virtual-machine).
+    * `host` (string) - Chooses the type of the host-end, which can be
+      either `app` (application) or `vm` (another virtual-machine).
   
-    * `yield` (bool)      - This is an optional boolean that specifies
-      whether the vm should yield the cpu when polling the port. By
+    * `yield` (bool) - This is an optional boolean that specifies whether
+      the virtual machine should yield the CPU when polling the port. By
       default, the builder will assume this as `FALSE`.
   
   * `AUTO:(yield)` - Specifies to use auto-detection to determine the
-    serial port to use. This has one option to determine how the VM should
-    support the serial port.
+    serial port to use. This has one option to determine how the virtual
+    machine should support the serial port.
   
-    * `yield` (bool) - This is an optional boolean that specifies
-      whether the vm should yield the cpu when polling the port. By
+    * `yield` (bool) - This is an optional boolean that specifies whether
+      the virtual machine should yield the CPU when polling the port. By
       default, the builder will assume this as `FALSE`.
   
   * `NONE` - Specifies to not use a serial port. (default)
 
-- `parallel` (string) - This specifies a parallel port to add to the VM. It has the format of
-  `Type:option1,option2,...`. Type can be one of the following values:
+- `parallel` (string) - Add a parallel port to add to the virtual machine. Use a format of
+  `Type:option1,option2,...`. Allowed values for the field `Type` include:
   `FILE`, `DEVICE`, `AUTO`, or `NONE`.
   
-  * `FILE:path` 		- Specifies the path to the local file to be used
-    for the parallel port.
+  * `FILE:path` - Specifies the path to the local file to be used for the
+     parallel port.
   
-  * `DEVICE:path`	 	- Specifies the path to the local device to be used
-    for the parallel port.
+  * `DEVICE:path` - Specifies the path to the local device to be used for
+     the parallel port.
   
-  * `AUTO:direction`   - Specifies to use auto-detection to determine the
+  * `AUTO:direction` - Specifies to use auto-detection to determine the
     parallel port. Direction can be `BI` to specify bidirectional
     communication or `UNI` to specify unidirectional communication.
   
-  * `NONE` 			- Specifies to not use a parallel port. (default)
+  * `NONE` - Specifies to not use a parallel port. (default)
 
 <!-- End of code generated from the comments of the HWConfig struct in builder/vmware/common/hw_config.go; -->


### PR DESCRIPTION
### Description

Adds options to explicitly enable UEFI and Secure Boot (requires UEFI).

Introduces optional `firmware`. Allowed values are `bios`, `uefi`, and `uefi-secure` (for secure boot).  Defaults to the recommended firmware type for the guest operating system.

Note the use of "uefi" instead of "efi" as seen in `packer-plugin-vsphere` as this is more correct and aligns with the UI and the secure boot key in the `.vmx` file.

### Testing

```console
packer-plugin-vmware on  feat/uefi-secure-boot
➜ go fmt ./...

packer-plugin-vmware on  feat/uefi-secure-boot
➜ make generate
2024/06/30 23:20:31 Copying "docs" to ".docs/"
2024/06/30 23:20:31 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vmware on  feat/uefi-secure-boot [$!]
➜ make build

packer-plugin-vmware on  feat/uefi-secure-boot
➜ make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 6.592s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    2.165s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    1.739s

packer-plugin-vmware on  feat/uefi-secure-boot [$!] 
➜ make dev
packer plugins install --path packer-plugin-vmware "github.com/hashicorp/vmware"
Successfully installed plugin github.com/hashicorp/vmware from /Users/ryan/Library/Mobile Documents/com~apple~CloudDocs/Code/Personal/packer-plugin-vmware/packer-plugin-vmware to /Users/ryan/.packer.d/plugins/github.com/hashicorp/vmware/packer-plugin-vmware_v1.0.12-dev_x5.0_darwin_arm64
```

### Reference

Closes #58
