### PR TITLE
docs: update `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-## 1.0.1 (Upcoming)
+# Release History
 
-## 1.0.0 (June 15,  2021)
-
-* New Feature: Create initial snapshot of VM after clean-up [GH-21]
-* Enable hpet by default [GH-3]
-
-## 0.0.1 (April 19, 2021)
-
-* VMware Plugin break out from Packer core. Changes prior to break out can be found in [Packer's CHANGELOG](https://github.com/hashicorp/packer/blob/master/CHANGELOG.md).
+Please refer to [releases](https://github.com/hashicorp/packer-plugin-vmware/releases) for the release history.


### PR DESCRIPTION
### Description

Updates the `CHANGELOG.md` to simply remove the legacy content and redirect to the GitHub Releases.

Similar to https://github.com/hashicorp/packer-plugin-vsphere/pull/377.