### PR TITLE
refactor: export formats

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -814,39 +814,53 @@ provisioner](/packer/docs/provisioner/file).
 
 <!-- Code generated from the comments of the ExportConfig struct in builder/vmware/common/export_config.go; DO NOT EDIT MANUALLY -->
 
-- `format` (string) - Either "ovf", "ova" or "vmx", this specifies the output
-  format of the exported virtual machine. This defaults to "ovf" for
-  remote (esx) builds, and "vmx" for local builds.
-  Before using this option, you need to install ovftool.
-  Since ovftool is only capable of password based authentication
-  remote_password must be set when exporting the VM from a remote instance.
-  If you are building locally, Packer will create a vmx and then
-  export that vm to an ovf or ova. Packer will not delete the vmx and vmdk
-  files; this is left up to the user if you don't want to keep those
-  files.
+- `format` (string) - The output format of the exported virtual machine. Allowed values are
+  `ova`, `ovf`, or `vmx`. Defaults to `vmx` for local desktop hypervisors
+  and `ova` for remote hypervisors.
+  
+  For builds on a remote hypervisor, `remote_password` must be set when
+  exporting the virtual machine
+  
+  For builds on a local desktop hypervisor, the plugin will create a `.vmx`
+  and export the virtual machine as an `.ovf` or `.ova` file. THe plugin
+  will not delete the `.vmx` and `.vmdk` files. You must manually delete
+  these files if they are no longer needed.
+  
+  ~> **Note:** Ensure VMware OVF Tool is installed. For the latest version,
+  visit [VMware OVF Tool](https://developer.broadcom.com/tools/open-virtualization-format-ovf-tool/latest).
+  
+  ~> **Note:** For local builds, the plugin will create a `.vmx` and
+  supporting files in the output directory and will then export the
+  virtual machine to the specified format. These files are **not**
+  automatically cleaned up after the export process.
 
-- `ovftool_options` ([]string) - Extra options to pass to ovftool during export. Each item in the array
-  is a new argument. The options `--noSSLVerify`, `--skipManifestCheck`,
-  and `--targetType` are used by Packer for remote exports, and should not
-  be passed to this argument. For ovf/ova exports from local builds, Packer
-  does not automatically set any ovftool options.
+- `ovftool_options` ([]string) - Additional command-line arguments to send to VMware OVF Tool during the
+  export process. Each string in the array represents a separate
+  command-line argument.
+  
+  ~> **Important:** The options `--noSSLVerify`, `--skipManifestCheck`, and
+  `--targetType` are automatically applied by the plugin for remote exports
+  and should not be included in the options. For local OVF/OVA exports,
+  the plugin does not preset any VMware OVF Tool options by default.
+  
+  ~> **Note:** Ensure VMware OVF Tool is installed. For the latest version,
+  visit [VMware OVF Tool](https://developer.broadcom.com/tools/open-virtualization-format-ovf-tool/latest).
 
-- `skip_export` (bool) - Defaults to `false`. When true, Packer will not export the VM. This can
-  be useful if the build output is not the resultant image, but created
-  inside the VM.
+- `skip_export` (bool) - Skips the export of the virtual machine. This is useful if the build
+  output is not the resultant image, but created inside the virtual
+  machine. This is useful for debugging purposes. Defaults to `false`.
 
-- `keep_registered` (bool) - Set this to true if you would like to keep a remotely-built
-  VM registered with the remote ESXi server. If you do not need to export
-  the vm, then also set `skip_export: true` in order to avoid unnecessarily
-  using ovftool to export the vm. Defaults to false.
+- `keep_registered` (bool) - Determines whether a virtual machine built on a remote hypervisor should
+  remain registered after the build process. Setting this to `true` can be
+  useful if the virtual machine does not need to be exported. Defaults to
+  `false`.
 
-- `skip_compaction` (bool) - VMware-created disks are defragmented and
-  compacted at the end of the build process using vmware-vdiskmanager or
-  vmkfstools in ESXi. In certain rare cases, this might actually end up
-  making the resulting disks slightly larger. If you find this to be the case,
-  you can disable compaction using this configuration value. Defaults to
-  false. Default to true for ESXi when disk_type_id is not explicitly
-  defined and false otherwise.
+- `skip_compaction` (bool) - At the end of the build process, the plugin defragments and compacts the
+  disks using `vmware-vdiskmanager` or `vmkfstools` for ESXi environments.
+  In some cases, this process may result in slightly larger disk sizes.
+  If this occurs, you can opt to skip the disk compaction step by using
+  this setting. Defaults to `false`. Defaults to `true` for ESXi when
+  `disk_type_id` is not explicitly defined and `false`
 
 <!-- End of code generated from the comments of the ExportConfig struct in builder/vmware/common/export_config.go; -->
 

--- a/.web-docs/components/builder/vmx/README.md
+++ b/.web-docs/components/builder/vmx/README.md
@@ -373,39 +373,53 @@ boot time.
 
 <!-- Code generated from the comments of the ExportConfig struct in builder/vmware/common/export_config.go; DO NOT EDIT MANUALLY -->
 
-- `format` (string) - Either "ovf", "ova" or "vmx", this specifies the output
-  format of the exported virtual machine. This defaults to "ovf" for
-  remote (esx) builds, and "vmx" for local builds.
-  Before using this option, you need to install ovftool.
-  Since ovftool is only capable of password based authentication
-  remote_password must be set when exporting the VM from a remote instance.
-  If you are building locally, Packer will create a vmx and then
-  export that vm to an ovf or ova. Packer will not delete the vmx and vmdk
-  files; this is left up to the user if you don't want to keep those
-  files.
+- `format` (string) - The output format of the exported virtual machine. Allowed values are
+  `ova`, `ovf`, or `vmx`. Defaults to `vmx` for local desktop hypervisors
+  and `ova` for remote hypervisors.
+  
+  For builds on a remote hypervisor, `remote_password` must be set when
+  exporting the virtual machine
+  
+  For builds on a local desktop hypervisor, the plugin will create a `.vmx`
+  and export the virtual machine as an `.ovf` or `.ova` file. THe plugin
+  will not delete the `.vmx` and `.vmdk` files. You must manually delete
+  these files if they are no longer needed.
+  
+  ~> **Note:** Ensure VMware OVF Tool is installed. For the latest version,
+  visit [VMware OVF Tool](https://developer.broadcom.com/tools/open-virtualization-format-ovf-tool/latest).
+  
+  ~> **Note:** For local builds, the plugin will create a `.vmx` and
+  supporting files in the output directory and will then export the
+  virtual machine to the specified format. These files are **not**
+  automatically cleaned up after the export process.
 
-- `ovftool_options` ([]string) - Extra options to pass to ovftool during export. Each item in the array
-  is a new argument. The options `--noSSLVerify`, `--skipManifestCheck`,
-  and `--targetType` are used by Packer for remote exports, and should not
-  be passed to this argument. For ovf/ova exports from local builds, Packer
-  does not automatically set any ovftool options.
+- `ovftool_options` ([]string) - Additional command-line arguments to send to VMware OVF Tool during the
+  export process. Each string in the array represents a separate
+  command-line argument.
+  
+  ~> **Important:** The options `--noSSLVerify`, `--skipManifestCheck`, and
+  `--targetType` are automatically applied by the plugin for remote exports
+  and should not be included in the options. For local OVF/OVA exports,
+  the plugin does not preset any VMware OVF Tool options by default.
+  
+  ~> **Note:** Ensure VMware OVF Tool is installed. For the latest version,
+  visit [VMware OVF Tool](https://developer.broadcom.com/tools/open-virtualization-format-ovf-tool/latest).
 
-- `skip_export` (bool) - Defaults to `false`. When true, Packer will not export the VM. This can
-  be useful if the build output is not the resultant image, but created
-  inside the VM.
+- `skip_export` (bool) - Skips the export of the virtual machine. This is useful if the build
+  output is not the resultant image, but created inside the virtual
+  machine. This is useful for debugging purposes. Defaults to `false`.
 
-- `keep_registered` (bool) - Set this to true if you would like to keep a remotely-built
-  VM registered with the remote ESXi server. If you do not need to export
-  the vm, then also set `skip_export: true` in order to avoid unnecessarily
-  using ovftool to export the vm. Defaults to false.
+- `keep_registered` (bool) - Determines whether a virtual machine built on a remote hypervisor should
+  remain registered after the build process. Setting this to `true` can be
+  useful if the virtual machine does not need to be exported. Defaults to
+  `false`.
 
-- `skip_compaction` (bool) - VMware-created disks are defragmented and
-  compacted at the end of the build process using vmware-vdiskmanager or
-  vmkfstools in ESXi. In certain rare cases, this might actually end up
-  making the resulting disks slightly larger. If you find this to be the case,
-  you can disable compaction using this configuration value. Defaults to
-  false. Default to true for ESXi when disk_type_id is not explicitly
-  defined and false otherwise.
+- `skip_compaction` (bool) - At the end of the build process, the plugin defragments and compacts the
+  disks using `vmware-vdiskmanager` or `vmkfstools` for ESXi environments.
+  In some cases, this process may result in slightly larger disk sizes.
+  If this occurs, you can opt to skip the disk compaction step by using
+  this setting. Defaults to `false`. Defaults to `true` for ESXi when
+  `disk_type_id` is not explicitly defined and `false`
 
 <!-- End of code generated from the comments of the ExportConfig struct in builder/vmware/common/export_config.go; -->
 

--- a/builder/vmware/common/export_config.go
+++ b/builder/vmware/common/export_config.go
@@ -7,54 +7,79 @@ package common
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 )
 
+// Set the export formats for the virtual machine.
+const (
+	ExportFormatOvf = "ovf"
+	ExportFormatOva = "ova"
+	ExportFormatVmx = "vmx"
+)
+
+// allowedFormatValues is a list of allowed export formats for the virtual
+// machine.
+var allowedExportFormats = []string{ExportFormatOvf, ExportFormatOva, ExportFormatVmx}
+
 type ExportConfig struct {
-	// Either "ovf", "ova" or "vmx", this specifies the output
-	// format of the exported virtual machine. This defaults to "ovf" for
-	// remote (esx) builds, and "vmx" for local builds.
-	// Before using this option, you need to install ovftool.
-	// Since ovftool is only capable of password based authentication
-	// remote_password must be set when exporting the VM from a remote instance.
-	// If you are building locally, Packer will create a vmx and then
-	// export that vm to an ovf or ova. Packer will not delete the vmx and vmdk
-	// files; this is left up to the user if you don't want to keep those
-	// files.
+	// The output format of the exported virtual machine. Allowed values are
+	// `ova`, `ovf`, or `vmx`. Defaults to `vmx` for local desktop hypervisors
+	// and `ova` for remote hypervisors.
+	//
+	// For builds on a remote hypervisor, `remote_password` must be set when
+	// exporting the virtual machine
+	//
+	// For builds on a local desktop hypervisor, the plugin will create a `.vmx`
+	// and export the virtual machine as an `.ovf` or `.ova` file. THe plugin
+	// will not delete the `.vmx` and `.vmdk` files. You must manually delete
+	// these files if they are no longer needed.
+	//
+	// ~> **Note:** Ensure VMware OVF Tool is installed. For the latest version,
+	// visit [VMware OVF Tool](https://developer.broadcom.com/tools/open-virtualization-format-ovf-tool/latest).
+	//
+	// ~> **Note:** For local builds, the plugin will create a `.vmx` and
+	// supporting files in the output directory and will then export the
+	// virtual machine to the specified format. These files are **not**
+	// automatically cleaned up after the export process.
 	Format string `mapstructure:"format" required:"false"`
-	// Extra options to pass to ovftool during export. Each item in the array
-	// is a new argument. The options `--noSSLVerify`, `--skipManifestCheck`,
-	// and `--targetType` are used by Packer for remote exports, and should not
-	// be passed to this argument. For ovf/ova exports from local builds, Packer
-	// does not automatically set any ovftool options.
+	// Additional command-line arguments to send to VMware OVF Tool during the
+	// export process. Each string in the array represents a separate
+	// command-line argument.
+	//
+	// ~> **Important:** The options `--noSSLVerify`, `--skipManifestCheck`, and
+	// `--targetType` are automatically applied by the plugin for remote exports
+	// and should not be included in the options. For local OVF/OVA exports,
+	// the plugin does not preset any VMware OVF Tool options by default.
+	//
+	// ~> **Note:** Ensure VMware OVF Tool is installed. For the latest version,
+	// visit [VMware OVF Tool](https://developer.broadcom.com/tools/open-virtualization-format-ovf-tool/latest).
 	OVFToolOptions []string `mapstructure:"ovftool_options" required:"false"`
-	// Defaults to `false`. When true, Packer will not export the VM. This can
-	// be useful if the build output is not the resultant image, but created
-	// inside the VM.
+	// Skips the export of the virtual machine. This is useful if the build
+	// output is not the resultant image, but created inside the virtual
+	// machine. This is useful for debugging purposes. Defaults to `false`.
 	SkipExport bool `mapstructure:"skip_export" required:"false"`
-	// Set this to true if you would like to keep a remotely-built
-	// VM registered with the remote ESXi server. If you do not need to export
-	// the vm, then also set `skip_export: true` in order to avoid unnecessarily
-	// using ovftool to export the vm. Defaults to false.
+	// Determines whether a virtual machine built on a remote hypervisor should
+	// remain registered after the build process. Setting this to `true` can be
+	// useful if the virtual machine does not need to be exported. Defaults to
+	// `false`.
 	KeepRegistered bool `mapstructure:"keep_registered" required:"false"`
-	// VMware-created disks are defragmented and
-	// compacted at the end of the build process using vmware-vdiskmanager or
-	// vmkfstools in ESXi. In certain rare cases, this might actually end up
-	// making the resulting disks slightly larger. If you find this to be the case,
-	// you can disable compaction using this configuration value. Defaults to
-	// false. Default to true for ESXi when disk_type_id is not explicitly
-	// defined and false otherwise.
+	// At the end of the build process, the plugin defragments and compacts the
+	// disks using `vmware-vdiskmanager` or `vmkfstools` for ESXi environments.
+	// In some cases, this process may result in slightly larger disk sizes.
+	// If this occurs, you can opt to skip the disk compaction step by using
+	// this setting. Defaults to `false`. Defaults to `true` for ESXi when
+	// `disk_type_id` is not explicitly defined and `false`
 	SkipCompaction bool `mapstructure:"skip_compaction" required:"false"`
 }
 
 func (c *ExportConfig) Prepare(ctx *interpolate.Context) []error {
 	var errs []error
-	if c.Format != "" {
-		if !(c.Format == "ova" || c.Format == "ovf" || c.Format == "vmx") {
-			errs = append(
-				errs, fmt.Errorf("format must be one of ova, ovf, or vmx"))
-		}
+
+	if (c.Format != "") && (!slices.Contains(allowedExportFormats, c.Format)) {
+		errs = append(errs, fmt.Errorf("invalid 'format' type specified: %s; must be one of %s", c.Format, strings.Join(allowedExportFormats, ", ")))
 	}
 
 	return errs

--- a/docs-partials/builder/vmware/common/ExportConfig-not-required.mdx
+++ b/docs-partials/builder/vmware/common/ExportConfig-not-required.mdx
@@ -1,37 +1,51 @@
 <!-- Code generated from the comments of the ExportConfig struct in builder/vmware/common/export_config.go; DO NOT EDIT MANUALLY -->
 
-- `format` (string) - Either "ovf", "ova" or "vmx", this specifies the output
-  format of the exported virtual machine. This defaults to "ovf" for
-  remote (esx) builds, and "vmx" for local builds.
-  Before using this option, you need to install ovftool.
-  Since ovftool is only capable of password based authentication
-  remote_password must be set when exporting the VM from a remote instance.
-  If you are building locally, Packer will create a vmx and then
-  export that vm to an ovf or ova. Packer will not delete the vmx and vmdk
-  files; this is left up to the user if you don't want to keep those
-  files.
+- `format` (string) - The output format of the exported virtual machine. Allowed values are
+  `ova`, `ovf`, or `vmx`. Defaults to `vmx` for local desktop hypervisors
+  and `ova` for remote hypervisors.
+  
+  For builds on a remote hypervisor, `remote_password` must be set when
+  exporting the virtual machine
+  
+  For builds on a local desktop hypervisor, the plugin will create a `.vmx`
+  and export the virtual machine as an `.ovf` or `.ova` file. THe plugin
+  will not delete the `.vmx` and `.vmdk` files. You must manually delete
+  these files if they are no longer needed.
+  
+  ~> **Note:** Ensure VMware OVF Tool is installed. For the latest version,
+  visit [VMware OVF Tool](https://developer.broadcom.com/tools/open-virtualization-format-ovf-tool/latest).
+  
+  ~> **Note:** For local builds, the plugin will create a `.vmx` and
+  supporting files in the output directory and will then export the
+  virtual machine to the specified format. These files are **not**
+  automatically cleaned up after the export process.
 
-- `ovftool_options` ([]string) - Extra options to pass to ovftool during export. Each item in the array
-  is a new argument. The options `--noSSLVerify`, `--skipManifestCheck`,
-  and `--targetType` are used by Packer for remote exports, and should not
-  be passed to this argument. For ovf/ova exports from local builds, Packer
-  does not automatically set any ovftool options.
+- `ovftool_options` ([]string) - Additional command-line arguments to send to VMware OVF Tool during the
+  export process. Each string in the array represents a separate
+  command-line argument.
+  
+  ~> **Important:** The options `--noSSLVerify`, `--skipManifestCheck`, and
+  `--targetType` are automatically applied by the plugin for remote exports
+  and should not be included in the options. For local OVF/OVA exports,
+  the plugin does not preset any VMware OVF Tool options by default.
+  
+  ~> **Note:** Ensure VMware OVF Tool is installed. For the latest version,
+  visit [VMware OVF Tool](https://developer.broadcom.com/tools/open-virtualization-format-ovf-tool/latest).
 
-- `skip_export` (bool) - Defaults to `false`. When true, Packer will not export the VM. This can
-  be useful if the build output is not the resultant image, but created
-  inside the VM.
+- `skip_export` (bool) - Skips the export of the virtual machine. This is useful if the build
+  output is not the resultant image, but created inside the virtual
+  machine. This is useful for debugging purposes. Defaults to `false`.
 
-- `keep_registered` (bool) - Set this to true if you would like to keep a remotely-built
-  VM registered with the remote ESXi server. If you do not need to export
-  the vm, then also set `skip_export: true` in order to avoid unnecessarily
-  using ovftool to export the vm. Defaults to false.
+- `keep_registered` (bool) - Determines whether a virtual machine built on a remote hypervisor should
+  remain registered after the build process. Setting this to `true` can be
+  useful if the virtual machine does not need to be exported. Defaults to
+  `false`.
 
-- `skip_compaction` (bool) - VMware-created disks are defragmented and
-  compacted at the end of the build process using vmware-vdiskmanager or
-  vmkfstools in ESXi. In certain rare cases, this might actually end up
-  making the resulting disks slightly larger. If you find this to be the case,
-  you can disable compaction using this configuration value. Defaults to
-  false. Default to true for ESXi when disk_type_id is not explicitly
-  defined and false otherwise.
+- `skip_compaction` (bool) - At the end of the build process, the plugin defragments and compacts the
+  disks using `vmware-vdiskmanager` or `vmkfstools` for ESXi environments.
+  In some cases, this process may result in slightly larger disk sizes.
+  If this occurs, you can opt to skip the disk compaction step by using
+  this setting. Defaults to `false`. Defaults to `true` for ESXi when
+  `disk_type_id` is not explicitly defined and `false`
 
 <!-- End of code generated from the comments of the ExportConfig struct in builder/vmware/common/export_config.go; -->


### PR DESCRIPTION
### Description

Refactors to use `allowedFormatValues` for export options.

### Testing

```console
packer-plugin-vmware on  refactor/export-formats
➜ go fmt ./... 

packer-plugin-vmware on  refactor/export-formats
➜ make generate
2024/07/02 23:39:08 Copying "docs" to ".docs/"
2024/07/02 23:39:08 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vmware on  refactor/export-formats
➜ make build

packer-plugin-vmware on  refactor/export-formats
➜ make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 6.625s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    1.852s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    2.247s

packer-plugin-vmware on  refactor/export-formats
➜ make dev
packer plugins install --path packer-plugin-vmware "github.com/hashicorp/vmware"
Successfully installed plugin github.com/hashicorp/vmware from /Users/ryan/Library/Mobile Documents/com~apple~CloudDocs/Code/Personal/packer-plugin-vmware/packer-plugin-vmware to /Users/ryan/.packer.d/plugins/github.com/hashicorp/vmware/packer-plugin-vmware_v1.0.12-dev_x5.0_darwin_arm64
```