### PR TITLE
chore: remove legacy `// +build` syntax

### DIFF
--- a/builder/vmware/common/driver_player5_windows.go
+++ b/builder/vmware/common/driver_player5_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build windows
-// +build windows
 
 package common
 

--- a/builder/vmware/common/driver_player6_windows.go
+++ b/builder/vmware/common/driver_player6_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build windows
-// +build windows
 
 package common
 

--- a/builder/vmware/common/driver_player_unix.go
+++ b/builder/vmware/common/driver_player_unix.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !windows
-// +build !windows
 
 // These functions are compatible with WS 9 and 10 on *NIX
 package common

--- a/builder/vmware/common/driver_workstation10_windows.go
+++ b/builder/vmware/common/driver_workstation10_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build windows
-// +build windows
 
 package common
 

--- a/builder/vmware/common/driver_workstation9_windows.go
+++ b/builder/vmware/common/driver_workstation9_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build windows
-// +build windows
 
 package common
 

--- a/builder/vmware/common/driver_workstation_unix.go
+++ b/builder/vmware/common/driver_workstation_unix.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !windows
-// +build !windows
 
 // These functions are compatible with WS 9 and 10 on *NIX
 package common

--- a/builder/vmware/common/driver_workstation_unix_test.go
+++ b/builder/vmware/common/driver_workstation_unix_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !windows
-// +build !windows
 
 package common
 


### PR DESCRIPTION
### Description

Removes the legacy `// +build` syntax.

The `//go:build` syntax was introduced in Go 1.17 to replace the older `// +build` syntax, offering a more readable and flexible way to specify build constraints.

For Go 1.17 and later:

- Use the `//go:build` syntax for specifying build constraints.
- The `// +build` syntax is still recognized for backward compatibility but is considered deprecated in new code.

For Go versions before 1.17:

- Only the `// +build` syntax is recognized

Based on the version used in this project, the use of the following:

```go
//go:build !windows
// +build !windows
```

... can be simplified to:

```go
//go:build !windows
```
