### PR TITLE
docs: term corrections

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -552,7 +552,7 @@ provisioner](/packer/docs/provisioner/file).
 - `remote_private_key_file` (string) - The SSH key for access to the remote machine.
 
 - `skip_validate_credentials` (bool) - When Packer is preparing to run a
-  remote esxi build, and export is not disable, by default it runs a no-op
+  remote hypervisor build, and export is not disable, by default it runs a no-op
   ovftool command to make sure that the remote_username and remote_password
   given are valid. If you set this flag to true, Packer will skip this
   validation. Default: false.
@@ -673,7 +673,7 @@ provisioner](/packer/docs/provisioner/file).
   This may be relative or absolute. If relative, the path is relative to
   the working directory when packer is executed.
   
-  If you are running a remote esx build, the output_dir is the path on your
+  If you are running a remote hypervisor build, the output_dir is the path on your
   local machine (the machine running Packer) to which Packer will export
   the vm if you have `"skip_export": false`. If you want to manage the
   virtual machine's path on the remote datastore, use `remote_output_dir`.
@@ -684,7 +684,7 @@ provisioner](/packer/docs/provisioner/file).
   By default this is output-BUILDNAME where "BUILDNAME" is the name of the
   build.
 
-- `remote_output_directory` (string) - This is the directoy on your remote esx host where you will save your
+- `remote_output_directory` (string) - This is the directory on your remote hypervisor where you will save your
   vm, relative to your remote_datastore.
   
   This option's default value is your `vm_name`, and the final path of your
@@ -699,7 +699,7 @@ provisioner](/packer/docs/provisioner/file).
   exist. However, Packer will create all directories defined in the option
   that do not currently exist.
   
-  This option will be ignored unless you are building on a remote esx host.
+  This option will be ignored unless you are building on a remote hypervisor.
 
 <!-- End of code generated from the comments of the OutputConfig struct in builder/vmware/common/output_config.go; -->
 

--- a/.web-docs/components/builder/vmx/README.md
+++ b/.web-docs/components/builder/vmx/README.md
@@ -432,7 +432,7 @@ boot time.
   This may be relative or absolute. If relative, the path is relative to
   the working directory when packer is executed.
   
-  If you are running a remote esx build, the output_dir is the path on your
+  If you are running a remote hypervisor build, the output_dir is the path on your
   local machine (the machine running Packer) to which Packer will export
   the vm if you have `"skip_export": false`. If you want to manage the
   virtual machine's path on the remote datastore, use `remote_output_dir`.
@@ -443,7 +443,7 @@ boot time.
   By default this is output-BUILDNAME where "BUILDNAME" is the name of the
   build.
 
-- `remote_output_directory` (string) - This is the directoy on your remote esx host where you will save your
+- `remote_output_directory` (string) - This is the directory on your remote hypervisor where you will save your
   vm, relative to your remote_datastore.
   
   This option's default value is your `vm_name`, and the final path of your
@@ -458,7 +458,7 @@ boot time.
   exist. However, Packer will create all directories defined in the option
   that do not currently exist.
   
-  This option will be ignored unless you are building on a remote esx host.
+  This option will be ignored unless you are building on a remote hypervisor.
 
 <!-- End of code generated from the comments of the OutputConfig struct in builder/vmware/common/output_config.go; -->
 
@@ -557,7 +557,7 @@ boot time.
 - `remote_private_key_file` (string) - The SSH key for access to the remote machine.
 
 - `skip_validate_credentials` (bool) - When Packer is preparing to run a
-  remote esxi build, and export is not disable, by default it runs a no-op
+  remote hypervisor build, and export is not disable, by default it runs a no-op
   ovftool command to make sure that the remote_username and remote_password
   given are valid. If you set this flag to true, Packer will skip this
   validation. Default: false.

--- a/builder/vmware/common/driver_config.go
+++ b/builder/vmware/common/driver_config.go
@@ -47,7 +47,7 @@ type DriverConfig struct {
 	// The SSH key for access to the remote machine.
 	RemotePrivateKey string `mapstructure:"remote_private_key_file" required:"false"`
 	// When Packer is preparing to run a
-	// remote esxi build, and export is not disable, by default it runs a no-op
+	// remote hypervisor build, and export is not disable, by default it runs a no-op
 	// ovftool command to make sure that the remote_username and remote_password
 	// given are valid. If you set this flag to true, Packer will skip this
 	// validation. Default: false.

--- a/builder/vmware/common/driver_esx5.go
+++ b/builder/vmware/common/driver_esx5.go
@@ -299,7 +299,7 @@ func (d *ESX5Driver) ToolsInstall() error {
 
 func (d *ESX5Driver) Verify() error {
 	// Ensure that NetworkMapper is nil, since the mapping of device<->network
-	// is handled by ESX and thus can't be performed by packer unless we
+	// is handled by ESXi and thus can't be performed by packer unless we
 	// query things.
 
 	// FIXME: If we want to expose the network devices to the user, then we can
@@ -464,7 +464,7 @@ func (d *ESX5Driver) HostAddress(multistep.StateBag) (string, error) {
 }
 
 func (d *ESX5Driver) GuestAddress(multistep.StateBag) (string, error) {
-	// list all the interfaces on the esx host
+	// list all the interfaces on the ESXi host
 	r, err := d.esxcli("network", "ip", "interface", "list")
 	if err != nil {
 		return "", fmt.Errorf("unable to retrieve host interfaces : %v", err)
@@ -479,7 +479,7 @@ func (d *ESX5Driver) GuestAddress(multistep.StateBag) (string, error) {
 		addrs[record["Name"]] = record["MAC Address"]
 	}
 
-	// list all the addresses on the esx host
+	// list all the addresses on the ESXi host
 	r, err = d.esxcli("network", "ip", "interface", "ipv4", "get")
 	if err != nil {
 		return "", fmt.Errorf("unable to retrieve host addresses : %v", err)

--- a/builder/vmware/common/output_config.go
+++ b/builder/vmware/common/output_config.go
@@ -18,7 +18,7 @@ type OutputConfig struct {
 	// This may be relative or absolute. If relative, the path is relative to
 	// the working directory when packer is executed.
 	//
-	// If you are running a remote esx build, the output_dir is the path on your
+	// If you are running a remote hypervisor build, the output_dir is the path on your
 	// local machine (the machine running Packer) to which Packer will export
 	// the vm if you have `"skip_export": false`. If you want to manage the
 	// virtual machine's path on the remote datastore, use `remote_output_dir`.
@@ -29,7 +29,7 @@ type OutputConfig struct {
 	// By default this is output-BUILDNAME where "BUILDNAME" is the name of the
 	// build.
 	OutputDir string `mapstructure:"output_directory" required:"false"`
-	// This is the directoy on your remote esx host where you will save your
+	// This is the directory on your remote hypervisor where you will save your
 	// vm, relative to your remote_datastore.
 	//
 	// This option's default value is your `vm_name`, and the final path of your
@@ -44,7 +44,7 @@ type OutputConfig struct {
 	// exist. However, Packer will create all directories defined in the option
 	// that do not currently exist.
 	//
-	// This option will be ignored unless you are building on a remote esx host.
+	// This option will be ignored unless you are building on a remote hypervisor.
 	RemoteOutputDir string `mapstructure:"remote_output_directory" required:"false"`
 }
 

--- a/builder/vmware/common/step_configure_vmx.go
+++ b/builder/vmware/common/step_configure_vmx.go
@@ -100,7 +100,7 @@ func (s *StepConfigureVMX) Run(ctx context.Context, state multistep.StateBag) mu
 		state.Put("temporaryDevices", tmpBuildDevices)
 	}
 
-	// If the build is taking place on a remote ESX server, the displayName
+	// If the build is taking place on a remote hypervisor, the displayName
 	// will be needed for discovery of the VM's IP address and for export
 	// of the VM. The displayName key should always be set in the VMX file,
 	// so error if we don't find it and the user has not set it in the config.

--- a/builder/vmware/common/step_output_dir.go
+++ b/builder/vmware/common/step_output_dir.go
@@ -55,7 +55,7 @@ func (s *StepOutputDir) SetOutputAndExportDirs(state multistep.StateBag) OutputD
 			// User set the remote output dir.
 			s.OutputConfig.OutputDir = s.OutputConfig.RemoteOutputDir
 		} else {
-			// Default output dir to vm name. On remote esx instance, this will
+			// Default output dir to vm name. On remote hypervisors, this will
 			// become something like /vmfs/volumes/mydatastore/vmname/vmname.vmx
 			s.OutputConfig.OutputDir = s.VMName
 		}

--- a/builder/vmware/common/step_register.go
+++ b/builder/vmware/common/step_register.go
@@ -52,7 +52,7 @@ func (s *StepRegister) Cleanup(state multistep.StateBag) {
 	_, cancelled := state.GetOk(multistep.StateCancelled)
 	_, halted := state.GetOk(multistep.StateHalted)
 	if (s.KeepRegistered) && (!cancelled && !halted) {
-		ui.Say("Keeping virtual machine registered with ESX host (keep_registered = true)")
+		ui.Say("Keeping virtual machine registered with ESXi host (keep_registered = true)")
 		return
 	}
 

--- a/docs-partials/builder/vmware/common/DriverConfig-not-required.mdx
+++ b/docs-partials/builder/vmware/common/DriverConfig-not-required.mdx
@@ -34,7 +34,7 @@
 - `remote_private_key_file` (string) - The SSH key for access to the remote machine.
 
 - `skip_validate_credentials` (bool) - When Packer is preparing to run a
-  remote esxi build, and export is not disable, by default it runs a no-op
+  remote hypervisor build, and export is not disable, by default it runs a no-op
   ovftool command to make sure that the remote_username and remote_password
   given are valid. If you set this flag to true, Packer will skip this
   validation. Default: false.

--- a/docs-partials/builder/vmware/common/OutputConfig-not-required.mdx
+++ b/docs-partials/builder/vmware/common/OutputConfig-not-required.mdx
@@ -5,7 +5,7 @@
   This may be relative or absolute. If relative, the path is relative to
   the working directory when packer is executed.
   
-  If you are running a remote esx build, the output_dir is the path on your
+  If you are running a remote hypervisor build, the output_dir is the path on your
   local machine (the machine running Packer) to which Packer will export
   the vm if you have `"skip_export": false`. If you want to manage the
   virtual machine's path on the remote datastore, use `remote_output_dir`.
@@ -16,7 +16,7 @@
   By default this is output-BUILDNAME where "BUILDNAME" is the name of the
   build.
 
-- `remote_output_directory` (string) - This is the directoy on your remote esx host where you will save your
+- `remote_output_directory` (string) - This is the directory on your remote hypervisor where you will save your
   vm, relative to your remote_datastore.
   
   This option's default value is your `vm_name`, and the final path of your
@@ -31,6 +31,6 @@
   exist. However, Packer will create all directories defined in the option
   that do not currently exist.
   
-  This option will be ignored unless you are building on a remote esx host.
+  This option will be ignored unless you are building on a remote hypervisor.
 
 <!-- End of code generated from the comments of the OutputConfig struct in builder/vmware/common/output_config.go; -->


### PR DESCRIPTION
### Description

Sweeps and corrects the following terms:

- "ESX" to "ESXi"
- "server" to "host"
- "remote esx" to "remote hypervisor"
