### PR TITLE
chore: deprecate `ssh_skip_request_pty`

### DIFF
--- a/builder/vmware/common/ssh_config.go
+++ b/builder/vmware/common/ssh_config.go
@@ -6,6 +6,8 @@
 package common
 
 import (
+	"log"
+
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 )
@@ -13,14 +15,14 @@ import (
 type SSHConfig struct {
 	Comm communicator.Config `mapstructure:",squash"`
 
-	// These are deprecated, but we keep them around for BC
-	// TODO(@mitchellh): remove
+	// TODO: Deprecated. Remove in next major release
 	SSHSkipRequestPty bool `mapstructure:"ssh_skip_request_pty"`
 }
 
 func (c *SSHConfig) Prepare(ctx *interpolate.Context) []error {
 	if c.SSHSkipRequestPty {
 		c.Comm.SSHPty = false
+		log.Printf("[WARN] 'ssh_skip_request_pty' is deprecated and will be removed in the next major release.")
 	}
 
 	return c.Comm.Prepare(ctx)


### PR DESCRIPTION
### Description

Deprecate `ssh_skip_request_pty` per comment:

https://github.com/hashicorp/packer-plugin-vmware/blob/330dc55d3b00bab6d95ae17ae541ce55f5efb50e/builder/vmware/common/ssh_config.go#L13-L19

### Testing

```console
packer-plugin-vmware on  chore/remove-ssh_skip_request_pty [$!] via 🐹 v1.22.5 
⇣7% ➜ go fmt ./... 

packer-plugin-vmware on  chore/remove-ssh_skip_request_pty [$!] via 🐹 v1.22.5 
⇣7% ➜ make generate
2024/07/07 22:12:12 Copying "docs" to ".docs/"
2024/07/07 22:12:12 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vmware on  chore/remove-ssh_skip_request_pty [$!] via 🐹 v1.22.5 
⇣7% ➜ make build   

packer-plugin-vmware on  chore/remove-ssh_skip_request_pty [$!] via 🐹 v1.22.5 took 3.2s 
⇣7% ➜ make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 6.603s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    2.159s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    1.716s
```
