### PR TITLE
docs: update disk configuration

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -129,29 +129,24 @@ necessary for this build to succeed and can be found further down the page.
 
 <!-- Code generated from the comments of the DiskConfig struct in builder/vmware/common/disk_config.go; DO NOT EDIT MANUALLY -->
 
-- `disk_additional_size` ([]uint) - The size(s) of any additional
-  hard disks for the VM in megabytes. If this is not specified then the VM
-  will only contain a primary hard disk. The builder uses expandable, not
-  fixed-size virtual hard disks, so the actual file representing the disk will
-  not use the full size unless it is full.
+- `disk_additional_size` ([]uint) - The size(s) of additional virtual hard disks in MB. If not specified,
+  the virtual machine will contain only a primary hard disk.
 
-- `disk_adapter_type` (string) - The adapter type of the VMware virtual disk to create. This option is
-  for advanced usage, modify only if you know what you're doing. Some of
-  the options you can specify are `ide`, `sata`, `nvme` or `scsi` (which
-  uses the "lsilogic" scsi interface by default). If you specify another
-  option, Packer will assume that you're specifying a `scsi` interface of
-  that specified type. For more information, please consult [Virtual Disk
-  Manager User's Guide](http://www.vmware.com/pdf/VirtualDiskManager.pdf)
-  for desktop VMware clients. For ESXi, refer to the proper ESXi
-  documentation.
-
-- `vmdk_name` (string) - The filename of the virtual disk that'll be created,
-  without the extension. This defaults to "disk".
-
-- `disk_type_id` (string) - The type of VMware virtual disk to create. This
-  option is for advanced usage.
+- `disk_adapter_type` (string) - The adapter type for additional virtual disk(s). Available options
+   are `ide`, `sata`, `nvme`, or `scsi`.
   
-    For desktop VMware clients:
+  ~> **Note:** When specifying `scsi` as the adapter type, the default
+  adapter type is set to `lsilogic`. If another option is specified, the
+  plugin will assume it is a `scsi` interface of that specified type.
+  
+  ~> **Note:** This option is intended for advanced users.
+
+- `vmdk_name` (string) - The filename for the virtual disk to create _without_ the `.vmdk`
+  extension. Defaults to `disk`.
+
+- `disk_type_id` (string) - The type of virtual disk to create.
+  
+    For local desktop hypervisors, the available options are:
   
     Type ID | Description
     ------- | ---
@@ -159,19 +154,21 @@ necessary for this build to succeed and can be found further down the page.
     `1`     | Growable virtual disk split into 2GB files (split sparse).
     `2`     | Preallocated virtual disk contained in a single file (monolithic flat).
     `3`     | Preallocated virtual disk split into 2GB files (split flat).
-    `4`     | Preallocated virtual disk compatible with ESX server (VMFS flat).
+    `4`     | Preallocated virtual disk compatible with ESXi (VMFS flat).
     `5`     | Compressed disk optimized for streaming.
   
-    The default is `1`.
+    Defaults to `1`.
   
-    For ESXi, this defaults to `zeroedthick`. The available options for ESXi
-    are: `zeroedthick`, `eagerzeroedthick`, `thin`. `rdm:dev`, `rdmp:dev`,
-    `2gbsparse` are not supported. Due to default disk compaction, when using
-    `zeroedthick` or `eagerzeroedthick` set `skip_compaction` to `true`.
+    For remote hypervisors, the available options are: `zeroedthick`,
+    `eagerzeroedthick`, and `thin`. Defaults to `zeroedthick`.
   
-    For more information, please consult the [Virtual Disk Manager User's
-    Guide](https://www.vmware.com/pdf/VirtualDiskManager.pdf) for desktop
-    VMware clients. For ESXi, refer to the proper ESXi documentation.
+    ~> **Note:** The `rdm:dev`, `rdmp:dev`, and `2gbsparse` types are not
+    supported for remote hypervisors.
+  
+    ~> **Note:** Set `skip_compaction` to `true` when using `zeroedthick`
+    or `eagerzeroedthick` due to default disk compaction behavior.
+  
+  ~> **Note:** This option is intended for advanced users.
 
 <!-- End of code generated from the comments of the DiskConfig struct in builder/vmware/common/disk_config.go; -->
 

--- a/.web-docs/components/builder/vmx/README.md
+++ b/.web-docs/components/builder/vmx/README.md
@@ -121,29 +121,24 @@ necessary for this build to succeed and can be found further down the page.
 
 <!-- Code generated from the comments of the DiskConfig struct in builder/vmware/common/disk_config.go; DO NOT EDIT MANUALLY -->
 
-- `disk_additional_size` ([]uint) - The size(s) of any additional
-  hard disks for the VM in megabytes. If this is not specified then the VM
-  will only contain a primary hard disk. The builder uses expandable, not
-  fixed-size virtual hard disks, so the actual file representing the disk will
-  not use the full size unless it is full.
+- `disk_additional_size` ([]uint) - The size(s) of additional virtual hard disks in MB. If not specified,
+  the virtual machine will contain only a primary hard disk.
 
-- `disk_adapter_type` (string) - The adapter type of the VMware virtual disk to create. This option is
-  for advanced usage, modify only if you know what you're doing. Some of
-  the options you can specify are `ide`, `sata`, `nvme` or `scsi` (which
-  uses the "lsilogic" scsi interface by default). If you specify another
-  option, Packer will assume that you're specifying a `scsi` interface of
-  that specified type. For more information, please consult [Virtual Disk
-  Manager User's Guide](http://www.vmware.com/pdf/VirtualDiskManager.pdf)
-  for desktop VMware clients. For ESXi, refer to the proper ESXi
-  documentation.
-
-- `vmdk_name` (string) - The filename of the virtual disk that'll be created,
-  without the extension. This defaults to "disk".
-
-- `disk_type_id` (string) - The type of VMware virtual disk to create. This
-  option is for advanced usage.
+- `disk_adapter_type` (string) - The adapter type for additional virtual disk(s). Available options
+   are `ide`, `sata`, `nvme`, or `scsi`.
   
-    For desktop VMware clients:
+  ~> **Note:** When specifying `scsi` as the adapter type, the default
+  adapter type is set to `lsilogic`. If another option is specified, the
+  plugin will assume it is a `scsi` interface of that specified type.
+  
+  ~> **Note:** This option is intended for advanced users.
+
+- `vmdk_name` (string) - The filename for the virtual disk to create _without_ the `.vmdk`
+  extension. Defaults to `disk`.
+
+- `disk_type_id` (string) - The type of virtual disk to create.
+  
+    For local desktop hypervisors, the available options are:
   
     Type ID | Description
     ------- | ---
@@ -151,19 +146,21 @@ necessary for this build to succeed and can be found further down the page.
     `1`     | Growable virtual disk split into 2GB files (split sparse).
     `2`     | Preallocated virtual disk contained in a single file (monolithic flat).
     `3`     | Preallocated virtual disk split into 2GB files (split flat).
-    `4`     | Preallocated virtual disk compatible with ESX server (VMFS flat).
+    `4`     | Preallocated virtual disk compatible with ESXi (VMFS flat).
     `5`     | Compressed disk optimized for streaming.
   
-    The default is `1`.
+    Defaults to `1`.
   
-    For ESXi, this defaults to `zeroedthick`. The available options for ESXi
-    are: `zeroedthick`, `eagerzeroedthick`, `thin`. `rdm:dev`, `rdmp:dev`,
-    `2gbsparse` are not supported. Due to default disk compaction, when using
-    `zeroedthick` or `eagerzeroedthick` set `skip_compaction` to `true`.
+    For remote hypervisors, the available options are: `zeroedthick`,
+    `eagerzeroedthick`, and `thin`. Defaults to `zeroedthick`.
   
-    For more information, please consult the [Virtual Disk Manager User's
-    Guide](https://www.vmware.com/pdf/VirtualDiskManager.pdf) for desktop
-    VMware clients. For ESXi, refer to the proper ESXi documentation.
+    ~> **Note:** The `rdm:dev`, `rdmp:dev`, and `2gbsparse` types are not
+    supported for remote hypervisors.
+  
+    ~> **Note:** Set `skip_compaction` to `true` when using `zeroedthick`
+    or `eagerzeroedthick` due to default disk compaction behavior.
+  
+  ~> **Note:** This option is intended for advanced users.
 
 <!-- End of code generated from the comments of the DiskConfig struct in builder/vmware/common/disk_config.go; -->
 

--- a/builder/vmware/common/disk_config.go
+++ b/builder/vmware/common/disk_config.go
@@ -10,29 +10,24 @@ import (
 )
 
 type DiskConfig struct {
-	// The size(s) of any additional
-	// hard disks for the VM in megabytes. If this is not specified then the VM
-	// will only contain a primary hard disk. The builder uses expandable, not
-	// fixed-size virtual hard disks, so the actual file representing the disk will
-	// not use the full size unless it is full.
+	// The size(s) of additional virtual hard disks in MB. If not specified,
+	// the virtual machine will contain only a primary hard disk.
 	AdditionalDiskSize []uint `mapstructure:"disk_additional_size" required:"false"`
-	// The adapter type of the VMware virtual disk to create. This option is
-	// for advanced usage, modify only if you know what you're doing. Some of
-	// the options you can specify are `ide`, `sata`, `nvme` or `scsi` (which
-	// uses the "lsilogic" scsi interface by default). If you specify another
-	// option, Packer will assume that you're specifying a `scsi` interface of
-	// that specified type. For more information, please consult [Virtual Disk
-	// Manager User's Guide](http://www.vmware.com/pdf/VirtualDiskManager.pdf)
-	// for desktop VMware clients. For ESXi, refer to the proper ESXi
-	// documentation.
-	DiskAdapterType string `mapstructure:"disk_adapter_type" required:"false"`
-	// The filename of the virtual disk that'll be created,
-	// without the extension. This defaults to "disk".
-	DiskName string `mapstructure:"vmdk_name" required:"false"`
-	// The type of VMware virtual disk to create. This
-	// option is for advanced usage.
+	// The adapter type for additional virtual disk(s). Available options
+	//  are `ide`, `sata`, `nvme`, or `scsi`.
 	//
-	//   For desktop VMware clients:
+	// ~> **Note:** When specifying `scsi` as the adapter type, the default
+	// adapter type is set to `lsilogic`. If another option is specified, the
+	// plugin will assume it is a `scsi` interface of that specified type.
+	//
+	// ~> **Note:** This option is intended for advanced users.
+	DiskAdapterType string `mapstructure:"disk_adapter_type" required:"false"`
+	// The filename for the virtual disk to create _without_ the `.vmdk`
+	// extension. Defaults to `disk`.
+	DiskName string `mapstructure:"vmdk_name" required:"false"`
+	// The type of virtual disk to create.
+	//
+	//   For local desktop hypervisors, the available options are:
 	//
 	//   Type ID | Description
 	//   ------- | ---
@@ -40,19 +35,21 @@ type DiskConfig struct {
 	//   `1`     | Growable virtual disk split into 2GB files (split sparse).
 	//   `2`     | Preallocated virtual disk contained in a single file (monolithic flat).
 	//   `3`     | Preallocated virtual disk split into 2GB files (split flat).
-	//   `4`     | Preallocated virtual disk compatible with ESX server (VMFS flat).
+	//   `4`     | Preallocated virtual disk compatible with ESXi (VMFS flat).
 	//   `5`     | Compressed disk optimized for streaming.
 	//
-	//   The default is `1`.
+	//   Defaults to `1`.
 	//
-	//   For ESXi, this defaults to `zeroedthick`. The available options for ESXi
-	//   are: `zeroedthick`, `eagerzeroedthick`, `thin`. `rdm:dev`, `rdmp:dev`,
-	//   `2gbsparse` are not supported. Due to default disk compaction, when using
-	//   `zeroedthick` or `eagerzeroedthick` set `skip_compaction` to `true`.
+	//   For remote hypervisors, the available options are: `zeroedthick`,
+	//   `eagerzeroedthick`, and `thin`. Defaults to `zeroedthick`.
 	//
-	//   For more information, please consult the [Virtual Disk Manager User's
-	//   Guide](https://www.vmware.com/pdf/VirtualDiskManager.pdf) for desktop
-	//   VMware clients. For ESXi, refer to the proper ESXi documentation.
+	//   ~> **Note:** The `rdm:dev`, `rdmp:dev`, and `2gbsparse` types are not
+	//   supported for remote hypervisors.
+	//
+	//   ~> **Note:** Set `skip_compaction` to `true` when using `zeroedthick`
+	//   or `eagerzeroedthick` due to default disk compaction behavior.
+	//
+	// ~> **Note:** This option is intended for advanced users.
 	DiskTypeId string `mapstructure:"disk_type_id" required:"false"`
 }
 
@@ -64,7 +61,6 @@ func (c *DiskConfig) Prepare(ctx *interpolate.Context) []error {
 	}
 
 	if c.DiskAdapterType == "" {
-		// Default is lsilogic
 		c.DiskAdapterType = "lsilogic"
 	}
 

--- a/docs-partials/builder/vmware/common/DiskConfig-not-required.mdx
+++ b/docs-partials/builder/vmware/common/DiskConfig-not-required.mdx
@@ -1,28 +1,23 @@
 <!-- Code generated from the comments of the DiskConfig struct in builder/vmware/common/disk_config.go; DO NOT EDIT MANUALLY -->
 
-- `disk_additional_size` ([]uint) - The size(s) of any additional
-  hard disks for the VM in megabytes. If this is not specified then the VM
-  will only contain a primary hard disk. The builder uses expandable, not
-  fixed-size virtual hard disks, so the actual file representing the disk will
-  not use the full size unless it is full.
+- `disk_additional_size` ([]uint) - The size(s) of additional virtual hard disks in MB. If not specified,
+  the virtual machine will contain only a primary hard disk.
 
-- `disk_adapter_type` (string) - The adapter type of the VMware virtual disk to create. This option is
-  for advanced usage, modify only if you know what you're doing. Some of
-  the options you can specify are `ide`, `sata`, `nvme` or `scsi` (which
-  uses the "lsilogic" scsi interface by default). If you specify another
-  option, Packer will assume that you're specifying a `scsi` interface of
-  that specified type. For more information, please consult [Virtual Disk
-  Manager User's Guide](http://www.vmware.com/pdf/VirtualDiskManager.pdf)
-  for desktop VMware clients. For ESXi, refer to the proper ESXi
-  documentation.
-
-- `vmdk_name` (string) - The filename of the virtual disk that'll be created,
-  without the extension. This defaults to "disk".
-
-- `disk_type_id` (string) - The type of VMware virtual disk to create. This
-  option is for advanced usage.
+- `disk_adapter_type` (string) - The adapter type for additional virtual disk(s). Available options
+   are `ide`, `sata`, `nvme`, or `scsi`.
   
-    For desktop VMware clients:
+  ~> **Note:** When specifying `scsi` as the adapter type, the default
+  adapter type is set to `lsilogic`. If another option is specified, the
+  plugin will assume it is a `scsi` interface of that specified type.
+  
+  ~> **Note:** This option is intended for advanced users.
+
+- `vmdk_name` (string) - The filename for the virtual disk to create _without_ the `.vmdk`
+  extension. Defaults to `disk`.
+
+- `disk_type_id` (string) - The type of virtual disk to create.
+  
+    For local desktop hypervisors, the available options are:
   
     Type ID | Description
     ------- | ---
@@ -30,18 +25,20 @@
     `1`     | Growable virtual disk split into 2GB files (split sparse).
     `2`     | Preallocated virtual disk contained in a single file (monolithic flat).
     `3`     | Preallocated virtual disk split into 2GB files (split flat).
-    `4`     | Preallocated virtual disk compatible with ESX server (VMFS flat).
+    `4`     | Preallocated virtual disk compatible with ESXi (VMFS flat).
     `5`     | Compressed disk optimized for streaming.
   
-    The default is `1`.
+    Defaults to `1`.
   
-    For ESXi, this defaults to `zeroedthick`. The available options for ESXi
-    are: `zeroedthick`, `eagerzeroedthick`, `thin`. `rdm:dev`, `rdmp:dev`,
-    `2gbsparse` are not supported. Due to default disk compaction, when using
-    `zeroedthick` or `eagerzeroedthick` set `skip_compaction` to `true`.
+    For remote hypervisors, the available options are: `zeroedthick`,
+    `eagerzeroedthick`, and `thin`. Defaults to `zeroedthick`.
   
-    For more information, please consult the [Virtual Disk Manager User's
-    Guide](https://www.vmware.com/pdf/VirtualDiskManager.pdf) for desktop
-    VMware clients. For ESXi, refer to the proper ESXi documentation.
+    ~> **Note:** The `rdm:dev`, `rdmp:dev`, and `2gbsparse` types are not
+    supported for remote hypervisors.
+  
+    ~> **Note:** Set `skip_compaction` to `true` when using `zeroedthick`
+    or `eagerzeroedthick` due to default disk compaction behavior.
+  
+  ~> **Note:** This option is intended for advanced users.
 
 <!-- End of code generated from the comments of the DiskConfig struct in builder/vmware/common/disk_config.go; -->


### PR DESCRIPTION
### Description

Updates the disk configuration documentation for clarity and readability.

### Testing

```console
packer-plugin-vmware on  docs/update-disk-configuration
➜ go fmt ./... 

packer-plugin-vmware on  docs/update-disk-configuration
➜ make generate
2024/07/08 14:55:29 Copying "docs" to ".docs/"
2024/07/08 14:55:29 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vmware on  docs/update-disk-configuration
➜ make build     

packer-plugin-vmware on  docs/update-disk-configuration
➜ make test 
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 7.263s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    3.022s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    3.922s

packer-plugin-vmware on  docs/update-disk-configuration
➜ make dev 
packer plugins install --path packer-plugin-vmware "github.com/hashicorp/vmware"
Successfully installed plugin github.com/hashicorp/vmware from /Users/johnsonryan/Library/Mobile Documents/com~apple~CloudDocs/Code/Work/packer-plugin-vmware1/packer-plugin-vmware to /Users/johnsonryan/.packer.d/plugins/github.com/hashicorp/vmware/packer-plugin-vmware_v1.0.12-dev_x5.0_darwin_amd64
```