### PR TITLE
docs: update vmxconfig

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -789,26 +789,32 @@ provisioner](/packer/docs/provisioner/file).
 
 <!-- Code generated from the comments of the VMXConfig struct in builder/vmware/common/vmx_config.go; DO NOT EDIT MANUALLY -->
 
-- `vmx_data` (map[string]string) - Arbitrary key/values to enter
-  into the virtual machine VMX file. This is for advanced users who want to
-  set properties that aren't yet supported by the builder.
+- `vmx_data` (map[string]string) - Key-value pairs that will be inserted into the virtual machine `.vmx`
+  file **before** the virtual machine is started. This is useful for
+  setting advanced properties that are not supported by the plugin.
+  
+  ~> **Note**: This option is intended for advanced users who understand
+  the ramifications of making changes to the `.vmx` file. This option is
+  not necessary for most users.
 
-- `vmx_data_post` (map[string]string) - Identical to vmx_data,
-  except that it is run after the virtual machine is shutdown, and before the
-  virtual machine is exported.
+- `vmx_data_post` (map[string]string) - Key-value pairs that will be inserted into the virtual machine `.vmx`
+  file **after** the virtual machine is started. This is useful for setting
+  advanced properties that are not supported by the plugin.
+  
+  ~> **Note**: This option is intended for advanced users who understand
+  the ramifications of making changes to the `.vmx` file. This option is
+  not necessary for most users.
 
-- `vmx_remove_ethernet_interfaces` (bool) - Remove all ethernet interfaces
-  from the VMX file after building. This is for advanced users who understand
-  the ramifications, but is useful for building Vagrant boxes since Vagrant
-  will create ethernet interfaces when provisioning a box. Defaults to
-  false.
+- `vmx_remove_ethernet_interfaces` (bool) - Remove all network adapters from virtual machine `.vmx` file after the
+  virtual machine build is complete. Defaults to `false`.
+  
+  ~> **Note**: This option is useful when building Vagrant boxes since
+  Vagrant will create interfaces when provisioning a box.
 
-- `display_name` (string) - The name that will appear in your vSphere client,
-  and will be used for the vmx basename. This will override the "displayname"
-  value in your vmx file. It will also override the "displayname" if you have
-  set it in the "vmx_data" Packer option. This option is useful if you are
-  chaining vmx builds and want to make sure that the display name of each step
-  in the chain is unique.
+- `display_name` (string) - The inventory display name for the virtual machine. If set, the value
+  provided will override any value set in the `vmx_data` option or in the
+  `.vmx` file. This option is useful if you are chaining builds and want to
+  ensure that the display name of each step in the chain is unique.
 
 <!-- End of code generated from the comments of the VMXConfig struct in builder/vmware/common/vmx_config.go; -->
 

--- a/.web-docs/components/builder/vmx/README.md
+++ b/.web-docs/components/builder/vmx/README.md
@@ -596,26 +596,32 @@ boot time.
 
 <!-- Code generated from the comments of the VMXConfig struct in builder/vmware/common/vmx_config.go; DO NOT EDIT MANUALLY -->
 
-- `vmx_data` (map[string]string) - Arbitrary key/values to enter
-  into the virtual machine VMX file. This is for advanced users who want to
-  set properties that aren't yet supported by the builder.
+- `vmx_data` (map[string]string) - Key-value pairs that will be inserted into the virtual machine `.vmx`
+  file **before** the virtual machine is started. This is useful for
+  setting advanced properties that are not supported by the plugin.
+  
+  ~> **Note**: This option is intended for advanced users who understand
+  the ramifications of making changes to the `.vmx` file. This option is
+  not necessary for most users.
 
-- `vmx_data_post` (map[string]string) - Identical to vmx_data,
-  except that it is run after the virtual machine is shutdown, and before the
-  virtual machine is exported.
+- `vmx_data_post` (map[string]string) - Key-value pairs that will be inserted into the virtual machine `.vmx`
+  file **after** the virtual machine is started. This is useful for setting
+  advanced properties that are not supported by the plugin.
+  
+  ~> **Note**: This option is intended for advanced users who understand
+  the ramifications of making changes to the `.vmx` file. This option is
+  not necessary for most users.
 
-- `vmx_remove_ethernet_interfaces` (bool) - Remove all ethernet interfaces
-  from the VMX file after building. This is for advanced users who understand
-  the ramifications, but is useful for building Vagrant boxes since Vagrant
-  will create ethernet interfaces when provisioning a box. Defaults to
-  false.
+- `vmx_remove_ethernet_interfaces` (bool) - Remove all network adapters from virtual machine `.vmx` file after the
+  virtual machine build is complete. Defaults to `false`.
+  
+  ~> **Note**: This option is useful when building Vagrant boxes since
+  Vagrant will create interfaces when provisioning a box.
 
-- `display_name` (string) - The name that will appear in your vSphere client,
-  and will be used for the vmx basename. This will override the "displayname"
-  value in your vmx file. It will also override the "displayname" if you have
-  set it in the "vmx_data" Packer option. This option is useful if you are
-  chaining vmx builds and want to make sure that the display name of each step
-  in the chain is unique.
+- `display_name` (string) - The inventory display name for the virtual machine. If set, the value
+  provided will override any value set in the `vmx_data` option or in the
+  `.vmx` file. This option is useful if you are chaining builds and want to
+  ensure that the display name of each step in the chain is unique.
 
 <!-- End of code generated from the comments of the VMXConfig struct in builder/vmware/common/vmx_config.go; -->
 

--- a/builder/vmware/common/vmx_config.go
+++ b/builder/vmware/common/vmx_config.go
@@ -10,26 +10,32 @@ import (
 )
 
 type VMXConfig struct {
-	// Arbitrary key/values to enter
-	// into the virtual machine VMX file. This is for advanced users who want to
-	// set properties that aren't yet supported by the builder.
+	// Key-value pairs that will be inserted into the virtual machine `.vmx`
+	// file **before** the virtual machine is started. This is useful for
+	// setting advanced properties that are not supported by the plugin.
+	//
+	// ~> **Note**: This option is intended for advanced users who understand
+	// the ramifications of making changes to the `.vmx` file. This option is
+	// not necessary for most users.
 	VMXData map[string]string `mapstructure:"vmx_data" required:"false"`
-	// Identical to vmx_data,
-	// except that it is run after the virtual machine is shutdown, and before the
-	// virtual machine is exported.
+	// Key-value pairs that will be inserted into the virtual machine `.vmx`
+	// file **after** the virtual machine is started. This is useful for setting
+	// advanced properties that are not supported by the plugin.
+	//
+	// ~> **Note**: This option is intended for advanced users who understand
+	// the ramifications of making changes to the `.vmx` file. This option is
+	// not necessary for most users.
 	VMXDataPost map[string]string `mapstructure:"vmx_data_post" required:"false"`
-	// Remove all ethernet interfaces
-	// from the VMX file after building. This is for advanced users who understand
-	// the ramifications, but is useful for building Vagrant boxes since Vagrant
-	// will create ethernet interfaces when provisioning a box. Defaults to
-	// false.
+	// Remove all network adapters from virtual machine `.vmx` file after the
+	// virtual machine build is complete. Defaults to `false`.
+	//
+	// ~> **Note**: This option is useful when building Vagrant boxes since
+	// Vagrant will create interfaces when provisioning a box.
 	VMXRemoveEthernet bool `mapstructure:"vmx_remove_ethernet_interfaces" required:"false"`
-	// The name that will appear in your vSphere client,
-	// and will be used for the vmx basename. This will override the "displayname"
-	// value in your vmx file. It will also override the "displayname" if you have
-	// set it in the "vmx_data" Packer option. This option is useful if you are
-	// chaining vmx builds and want to make sure that the display name of each step
-	// in the chain is unique.
+	// The inventory display name for the virtual machine. If set, the value
+	// provided will override any value set in the `vmx_data` option or in the
+	// `.vmx` file. This option is useful if you are chaining builds and want to
+	// ensure that the display name of each step in the chain is unique.
 	VMXDisplayName string `mapstructure:"display_name" required:"false"`
 }
 

--- a/docs-partials/builder/vmware/common/VMXConfig-not-required.mdx
+++ b/docs-partials/builder/vmware/common/VMXConfig-not-required.mdx
@@ -1,24 +1,30 @@
 <!-- Code generated from the comments of the VMXConfig struct in builder/vmware/common/vmx_config.go; DO NOT EDIT MANUALLY -->
 
-- `vmx_data` (map[string]string) - Arbitrary key/values to enter
-  into the virtual machine VMX file. This is for advanced users who want to
-  set properties that aren't yet supported by the builder.
+- `vmx_data` (map[string]string) - Key-value pairs that will be inserted into the virtual machine `.vmx`
+  file **before** the virtual machine is started. This is useful for
+  setting advanced properties that are not supported by the plugin.
+  
+  ~> **Note**: This option is intended for advanced users who understand
+  the ramifications of making changes to the `.vmx` file. This option is
+  not necessary for most users.
 
-- `vmx_data_post` (map[string]string) - Identical to vmx_data,
-  except that it is run after the virtual machine is shutdown, and before the
-  virtual machine is exported.
+- `vmx_data_post` (map[string]string) - Key-value pairs that will be inserted into the virtual machine `.vmx`
+  file **after** the virtual machine is started. This is useful for setting
+  advanced properties that are not supported by the plugin.
+  
+  ~> **Note**: This option is intended for advanced users who understand
+  the ramifications of making changes to the `.vmx` file. This option is
+  not necessary for most users.
 
-- `vmx_remove_ethernet_interfaces` (bool) - Remove all ethernet interfaces
-  from the VMX file after building. This is for advanced users who understand
-  the ramifications, but is useful for building Vagrant boxes since Vagrant
-  will create ethernet interfaces when provisioning a box. Defaults to
-  false.
+- `vmx_remove_ethernet_interfaces` (bool) - Remove all network adapters from virtual machine `.vmx` file after the
+  virtual machine build is complete. Defaults to `false`.
+  
+  ~> **Note**: This option is useful when building Vagrant boxes since
+  Vagrant will create interfaces when provisioning a box.
 
-- `display_name` (string) - The name that will appear in your vSphere client,
-  and will be used for the vmx basename. This will override the "displayname"
-  value in your vmx file. It will also override the "displayname" if you have
-  set it in the "vmx_data" Packer option. This option is useful if you are
-  chaining vmx builds and want to make sure that the display name of each step
-  in the chain is unique.
+- `display_name` (string) - The inventory display name for the virtual machine. If set, the value
+  provided will override any value set in the `vmx_data` option or in the
+  `.vmx` file. This option is useful if you are chaining builds and want to
+  ensure that the display name of each step in the chain is unique.
 
 <!-- End of code generated from the comments of the VMXConfig struct in builder/vmware/common/vmx_config.go; -->


### PR DESCRIPTION
### Description

Updates the documentation for the `.vmx` file configuration.

### Testing

```console
packer-plugin-vmware on  docs/update-vmxconfig
➜ go fmt ./... 

packer-plugin-vmware on  docs/update-vmxconfig
➜ make generate
2024/07/15 14:03:04 Copying "docs" to ".docs/"
2024/07/15 14:03:04 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vmware on  docs/update-vmxconfig
➜ make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 7.237s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    2.611s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    1.616s
```