### PR TITLE
fix: remote hypervisor snapshot creation

### DIFF
--- a/builder/vmware/common/step_create_snapshot.go
+++ b/builder/vmware/common/step_create_snapshot.go
@@ -11,28 +11,31 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 )
 
-// StepCreateSnapshot step creates the intial snapshot for the VM after clean-up.
+// StepCreateSnapshot step creates a snapshot for the virtual machine after the
+// build has been completed.
 type StepCreateSnapshot struct {
 	SnapshotName *string
 }
 
 func (s *StepCreateSnapshot) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	if *s.SnapshotName != "" { // if snapshot name is set create one, if not don't
-		driver := state.Get("driver").(Driver)
-		ui := state.Get("ui").(packersdk.Ui)
-
-		ui.Say("Creating inital snapshot")
-		vmFullPath := state.Get("vmx_path").(string)
-		if err := driver.CreateSnapshot(vmFullPath, *s.SnapshotName); err != nil {
-			err := fmt.Errorf("error creating snapshot: %s", err)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			return multistep.ActionHalt
-		}
-		state.Put("snapshot_created", true)
-	} else {
+	// If snapshot name is not set, skip snapshot creation.
+	if *s.SnapshotName == "" {
 		state.Put("snapshot_skipped", true)
+		return multistep.ActionContinue
 	}
+
+	driver := state.Get("driver").(Driver)
+	ui := state.Get("ui").(packersdk.Ui)
+
+	ui.Say("Creating snapshot of virtual machine...")
+	vmFullPath := state.Get("vmx_path").(string)
+	if err := driver.CreateSnapshot(vmFullPath, *s.SnapshotName); err != nil {
+		err := fmt.Errorf("error creating snapshot: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+	state.Put("snapshot_created", true)
 	return multistep.ActionContinue
 }
 

--- a/builder/vmware/common/step_create_snapshot_test.go
+++ b/builder/vmware/common/step_create_snapshot_test.go
@@ -29,24 +29,24 @@ func TestStepCreateSnapshot(t *testing.T) {
 	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
 		t.Fatalf("bad action: %#v", action)
 	}
+
 	if _, ok := state.GetOk("error"); ok {
-		t.Fatal("should NOT have error")
+		t.Fatal("should not error")
 	}
 
 	driver := state.Get("driver").(*DriverMock)
 	if !driver.CreateSnapshotCalled {
-		t.Fatalf("Should have called create snapshot.")
+		t.Fatalf("should call create snapshot")
 	}
 
-	if _, ok := state.GetOk("snapshot_skiped"); ok {
-		t.Fatalf("Should NOT skip snapshot creation")
+	if _, ok := state.GetOk("snapshot_skipped"); ok {
+		t.Fatalf("should not skip snapshot")
 	}
 
 	if _, ok := state.GetOk("snapshot_created"); !ok {
 		t.Fatalf("Should create snapshot")
 	}
 
-	// Cleanup
 	step.Cleanup(state)
 }
 
@@ -61,14 +61,13 @@ func TestStepCreateSnapshot_skip(t *testing.T) {
 		t.Fatalf("bad action: %#v", action)
 	}
 	if _, ok := state.GetOk("error"); ok {
-		t.Fatal("should NOT have error")
+		t.Fatal("should not error")
 	}
 
 	driver := state.Get("driver").(*DriverMock)
 	if driver.CreateSnapshotCalled {
-		t.Fatalf("Should NOT have called create snapshot.")
+		t.Fatalf("should not call create snapshot")
 	}
 
-	// Cleanup
 	step.Cleanup(state)
 }

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -188,11 +188,11 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			RemoveEthernetInterfaces: b.config.VMXConfig.VMXRemoveEthernet,
 			VNCEnabled:               !b.config.DisableVNC,
 		},
-		&vmwcommon.StepCreateSnapshot{
-			SnapshotName: &b.config.SnapshotName,
-		},
 		&vmwcommon.StepUploadVMX{
 			RemoteType: b.config.RemoteType,
+		},
+		&vmwcommon.StepCreateSnapshot{
+			SnapshotName: &b.config.SnapshotName,
 		},
 		&vmwcommon.StepExport{
 			Format:         b.config.Format,

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -182,11 +182,11 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			RemoveEthernetInterfaces: b.config.VMXConfig.VMXRemoveEthernet,
 			VNCEnabled:               !b.config.DisableVNC,
 		},
-		&vmwcommon.StepCreateSnapshot{
-			SnapshotName: &b.config.SnapshotName,
-		},
 		&vmwcommon.StepUploadVMX{
 			RemoteType: b.config.RemoteType,
+		},
+		&vmwcommon.StepCreateSnapshot{
+			SnapshotName: &b.config.SnapshotName,
 		},
 		&vmwcommon.StepExport{
 			Format:         b.config.Format,


### PR DESCRIPTION
### Description

Moves the snapshot creation step after the upload of the `.vmx` file to the remote hypervisor. When not set in this order, the virtual machine will not be set to run on the created snapshot.

### Testing

General

```console
packer-plugin-vmware on  fix/snapshot-creation [$!] via 🐹 v1.22.5 took 3.4s 
➜ go fmt ./...

packer-plugin-vmware on  fix/snapshot-creation [$!] via 🐹 v1.22.5 
➜ make generate
2024/07/15 22:04:53 Copying "docs" to ".docs/"
2024/07/15 22:04:53 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vmware on  fix/snapshot-creation [$!] via 🐹 v1.22.5 took 2.9s 
➜ make build

packer-plugin-vmware on  fix/snapshot-creation [$!] via 🐹 v1.22.5 
➜ make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 6.714s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    2.550s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    2.020s

packer-plugin-vmware on  fix/snapshot-creation [$!] via 🐹 v1.22.5 took 10.4s 
➜ make dev 
packer plugins install --path packer-plugin-vmware "github.com/hashicorp/vmware"
Successfully installed plugin github.com/hashicorp/vmware from /Users/ryan/Library/Mobile Documents/com~apple~CloudDocs/Code/Personal/packer-plugin-vmware/packer-plugin-vmware to /Users/ryan/.packer.d/plugins/github.com/hashicorp/vmware/packer-plugin-vmware_v1.0.12-dev_x5.0_darwin_arm64
```

Run

```console
==> vmware-iso.appliance: Deleting unnecessary VMware files...
    vmware-iso.appliance: Deleting: /vmfs/volumes/local/appliance/appliance.scoreboard
    vmware-iso.appliance: Deleting: /vmfs/volumes/local/appliance/vmware.log
==> vmware-iso.appliance: Cleaning VMX prior to finishing up...
    vmware-iso.appliance: Detaching ISO from CD-ROM device ide0:0...
    vmware-iso.appliance: Detaching ISO from CD-ROM device ide1:0...
    vmware-iso.appliance: Disabling VNC server...
==> vmware-iso.appliance: Creating snapshot of the virtual machine...
==> vmware-iso.appliance: Skipping export of virtual machine...
Build 'vmware-iso.appliance' finished after 2 minutes 29 seconds.

==> Wait completed after 2 minutes 29 seconds

==> Builds finished. The artifacts of successful builds are:
--> vmware-iso.appliance: VM files in directory: /vmfs/volumes/local/appliance
```

```text
sata0.present = "FALSE"
scsi0.pcislotnumber = "16"
scsi0.present = "TRUE"
scsi0.virtualdev = "pvscsi"
scsi0:0.filename = "disk-000001.vmdk" <--- expected result.
scsi0:0.present = "TRUE"
scsi0:0.redo = ""
```

### Reference

Closes #68

