### PR TITLE
chore: v1.1.0 dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,15 +6,8 @@ package version
 import "github.com/hashicorp/packer-plugin-sdk/version"
 
 var (
-	// Version is the main version number that is being run at the moment.
-	Version = "1.0.12"
-
-	// VersionPrerelease is A pre-release marker for the Version. If this is ""
-	// (empty string) then it means that it is a final release. Otherwise, this
-	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
+	Version           = "1.1.0"
 	VersionPrerelease = "dev"
-
-	// PluginVersion is used by the plugin set to allow Packer to recognize
-	// what version this plugin is.
-	PluginVersion = version.InitializePluginVersion(Version, VersionPrerelease)
+	VersionMetadata   = ""
+	PluginVersion     = version.NewPluginVersion(Version, VersionPrerelease, VersionMetadata)
 )


### PR DESCRIPTION
### Summary

- Updates `version/version.go` as v1.1.0 dev.
- Replaces the deprecated `InitializePluginVersion` with `NewPluginVersion` from `packer-plugin-sdk`, which is the recommended approach.
- Removed superfluous comments that are already included in the SDK.

### Testing

```console
packer-plugin-vmware on  chore/update-version [$] via 🐹 v1.22.6 
➜ make dev
packer plugins install --path packer-plugin-vmware "github.com/hashicorp/vmware"
Successfully installed plugin github.com/hashicorp/vmware from /Users/johnsonryan/Library/Mobile Documents/com~apple~CloudDocs/Code/Work/packer-plugin-vmware/packer-plugin-vmware to /Users/johnsonryan/.packer.d/plugins/github.com/hashicorp/vmware/packer-plugin-vmware_v1.1.0-dev_x5.0_darwin_amd64
```