### PR TITLE
chore(ci): add codeql analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: 00 00 * * 00
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - go
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+      # Install Go to use the version specified in go.mod.
+      # https://github.com/github/codeql-action/issues/1842#issuecomment-1704398087
+      - name: Setup Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c4fb451437765abf5018c6fbf22cce1a7da1e5cc
+        with:
+          languages: '${{ matrix.language }}'
+      - name: Autobuild
+        uses: >-
+          github/codeql-action/autobuild@c4fb451437765abf5018c6fbf22cce1a7da1e5cc
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@c4fb451437765abf5018c6fbf22cce1a7da1e5cc

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The plugin supports versions in accordance with the [Broadcom Product Lifecycle]
 
 **Go**:
 
-- [Go 1.21][golang-install]
+- [Go 1.21.0][golang-install]
 
   Required if building the plugin.
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21.0
 require (
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-getter/v2 v2.2.2
+	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl/v2 v2.19.1
 	github.com/hashicorp/packer-plugin-sdk v0.5.4
 	github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed
@@ -56,7 +57,6 @@ require (
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
-	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/serf v0.10.1 // indirect


### PR DESCRIPTION
### Summary

Adds CodeQL Analysis.

Required 1.N.P syntax in `go.mod` which is used in `go.version`.

(Also moved `hashicorp/go-version` to a direct requirement.)