### PR TITLE
chore: error technical debt

### DIFF
--- a/.web-docs/components/builder/vmx/README.md
+++ b/.web-docs/components/builder/vmx/README.md
@@ -65,7 +65,7 @@ JSON Example:
 
 - `linked` (bool) - By default Packer creates a 'full' clone of the virtual machine
   specified in source_path. The resultant virtual machine is fully
-  independant from the parent it was cloned from.
+  independent from the parent it was cloned from.
   
   Setting linked to true instead causes Packer to create the virtual
   machine as a 'linked' clone. Linked clones use and require ongoing

--- a/builder/vmware/common/driver_esx5.go
+++ b/builder/vmware/common/driver_esx5.go
@@ -436,13 +436,13 @@ func (d *ESX5Driver) HostAddress(multistep.StateBag) (string, error) {
 	// get the local address (the host)
 	host, _, err := net.SplitHostPort(conn.LocalAddr().String())
 	if err != nil {
-		return "", fmt.Errorf("unable to determine host address : %v", err)
+		return "", fmt.Errorf("unable to determine host address : %s", err)
 	}
 
 	// iterate through all the interfaces..
 	interfaces, err := net.Interfaces()
 	if err != nil {
-		return "", fmt.Errorf("unable to enumerate host interfaces : %v", err)
+		return "", fmt.Errorf("unable to enumerate host interfaces : %s", err)
 	}
 
 	for _, intf := range interfaces {
@@ -467,7 +467,7 @@ func (d *ESX5Driver) GuestAddress(multistep.StateBag) (string, error) {
 	// list all the interfaces on the ESXi host
 	r, err := d.esxcli("network", "ip", "interface", "list")
 	if err != nil {
-		return "", fmt.Errorf("unable to retrieve host interfaces : %v", err)
+		return "", fmt.Errorf("unable to retrieve host interfaces : %s", err)
 	}
 
 	// rip out the interface name and the MAC address from the csv output
@@ -482,7 +482,7 @@ func (d *ESX5Driver) GuestAddress(multistep.StateBag) (string, error) {
 	// list all the addresses on the ESXi host
 	r, err = d.esxcli("network", "ip", "interface", "ipv4", "get")
 	if err != nil {
-		return "", fmt.Errorf("unable to retrieve host addresses : %v", err)
+		return "", fmt.Errorf("unable to retrieve host addresses : %s", err)
 	}
 
 	// figure out the interface name that matches the specified d.Host address
@@ -501,7 +501,7 @@ func (d *ESX5Driver) GuestAddress(multistep.StateBag) (string, error) {
 	// find the MAC address according to the interface name
 	result, ok := addrs[intf]
 	if !ok {
-		return "", fmt.Errorf("unable to find address for guest interface")
+		return "", errors.New("unable to find address for guest interface")
 	}
 
 	// ..and we're good
@@ -516,7 +516,7 @@ func (d *ESX5Driver) VNCAddress(ctx context.Context, _ string, portMin, portMax 
 	//it will ignore any ports listened to by only localhost
 	r, err := d.esxcli("network", "ip", "connection", "list")
 	if err != nil {
-		err = fmt.Errorf("unable to retrieve network information for host : %v", err)
+		err = fmt.Errorf("unable to retrieve network information for host : %s", err)
 		return "", 0, err
 	}
 
@@ -856,7 +856,7 @@ func (d *ESX5Driver) VerifyChecksum(hash string, file string) bool {
 		Src: file + "?checksum=" + hash,
 	})
 	if err != nil {
-		log.Printf("[ERROR] Error parsing the checksum: %v", err)
+		log.Printf("[ERROR] Error parsing the checksum: %s", err)
 		return false
 	}
 

--- a/builder/vmware/common/driver_esx5_test.go
+++ b/builder/vmware/common/driver_esx5_test.go
@@ -73,7 +73,7 @@ func TestESX5Driver_CommHost(t *testing.T) {
 	var commConfig communicator.Config
 	err := config.Decode(&commConfig, nil, conf)
 	if err != nil {
-		t.Fatalf("error decoding config: %v", err)
+		t.Fatalf("error decoding config: %s", err)
 	}
 	state := new(multistep.BasicStateBag)
 	sshConfig := SSHConfig{Comm: commConfig}

--- a/builder/vmware/common/driver_fusion6.go
+++ b/builder/vmware/common/driver_fusion6.go
@@ -131,7 +131,7 @@ func (d *Fusion6Driver) ToolsIsoPath(k string) string {
 	cmd := exec.Command(vmxpath, "-v")
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		log.Printf("[DEBUG] failed to execute vmware-vmx command to get version %v", err)
+		log.Printf("[DEBUG] failed to execute vmware-vmx command to get version %s", err)
 		log.Printf("[DEBUG] continuing with default iso path for fusion6+.")
 		return filepath.Join(d.AppPath, "Contents", "Library", "isoimages", "x86_x64", k+".iso")
 	}

--- a/builder/vmware/common/driver_parser.go
+++ b/builder/vmware/common/driver_parser.go
@@ -6,6 +6,7 @@ package common
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log"
 	"math"
@@ -68,7 +69,7 @@ func tokenizeDhcpConfig(in chan byte) chan string {
 			}
 
 			// If we're in a quote, then we continue until we're not in a quote
-			// before we start looing for tokens
+			// before we start looking for tokens
 			if quote {
 				if by == '"' {
 					out <- state + string(by)
@@ -81,7 +82,7 @@ func tokenizeDhcpConfig(in chan byte) chan string {
 
 			switch by {
 			case '"':
-				// Otherwise we're outside any quotes and can process bytes normaly
+				// Otherwise we're outside any quotes and can process bytes normally
 				quote = true
 				state += string(by)
 				continue
@@ -240,10 +241,10 @@ func parseDhcpConfig(in chan string) (tkGroup, error) {
 			// that was because they were unterminated. Raise an error in that case.
 
 			if node.parent == nil {
-				return tkGroup{}, fmt.Errorf("refused to close the global declaration")
+				return tkGroup{}, errors.New("refused to close the global declaration")
 			}
 			if len(tokens) > 0 {
-				return tkGroup{}, fmt.Errorf("list of tokens was left unterminated : %v", tokens)
+				return tkGroup{}, fmt.Errorf("list of tokens was left unterminated: %v", tokens)
 			}
 			node = node.parent
 
@@ -415,12 +416,12 @@ func parseNetworkMapConfig(in chan string) (NetworkMap, error) {
 		switch tk {
 		case ".":
 			if len(state) != 1 {
-				return nil, fmt.Errorf("network index missing")
+				return nil, errors.New("network index missing")
 			}
 
 		case "=":
 			if len(state) != 2 {
-				return nil, fmt.Errorf("assigned to empty attribute")
+				return nil, errors.New("assigned to empty attribute")
 			}
 
 		case "\n":
@@ -1031,7 +1032,7 @@ func (e *configDeclaration) IP4() (net.IP, error) {
 		return nil, fmt.Errorf("more than one ipv4 address returned : %v", result)
 
 	} else if len(result) == 0 {
-		return nil, fmt.Errorf("no ipv4 address found")
+		return nil, errors.New("no IPv4 address found")
 	}
 
 	// Try and parse it as an IP4. If so, then it's good to return it as-is.
@@ -1064,7 +1065,7 @@ func (e *configDeclaration) IP6() (net.IP, error) {
 		return nil, fmt.Errorf("more than one ipv6 address returned : %v", result)
 
 	} else if len(result) == 0 {
-		return nil, fmt.Errorf("no ipv6 address found")
+		return nil, errors.New("no IPv6 address found")
 	}
 
 	// If we were able to parse it into an IP, then we can just return it.

--- a/builder/vmware/common/driver_parser_test.go
+++ b/builder/vmware/common/driver_parser_test.go
@@ -359,7 +359,7 @@ parameters : map[default-lease-time:1800 max-lease-time:7200]
 
 	config, err := ReadDhcpConfiguration(f)
 	if err != nil {
-		t.Fatalf("Unable to read dhcpd.conf samplpe: %s", err)
+		t.Fatalf("Unable to read dhcpd.conf sample: %s", err)
 	}
 
 	if len(config) != 3 {
@@ -429,7 +429,7 @@ func TestParserReadNetworkMap(t *testing.T) {
 
 	netmap, err := ReadNetworkMap(f)
 	if err != nil {
-		t.Fatalf("Unable to read netmap.conf samplpe: %s", err)
+		t.Fatalf("Unable to read netmap.conf sample: %s", err)
 	}
 
 	expected_keys := []string{"device", "name"}
@@ -711,7 +711,7 @@ func TestParserReadDhcpdLeaseEntry(t *testing.T) {
 
 	result, err := readDhcpdLeaseEntry(consumeLeaseString(test_1))
 	if err != nil {
-		t.Errorf("error parsing entry: %v", err)
+		t.Errorf("error parsing entry: %s", err)
 	}
 	if result.address != expected_1["address"] {
 		t.Errorf("expected address %v, got %v", expected_1["address"], result.address)
@@ -733,7 +733,7 @@ func TestParserReadDhcpdLeaseEntry(t *testing.T) {
 	}
 	result, err = readDhcpdLeaseEntry(consumeLeaseString(test_2))
 	if err != nil {
-		t.Errorf("error parsing entry: %v", err)
+		t.Errorf("error parsing entry: %s", err)
 	}
 	if result.address != expected_2["address"] {
 		t.Errorf("expected address %v, got %v", expected_2["address"], result.address)
@@ -896,7 +896,7 @@ func TestParserReadAppleDhcpdLeaseEntry(t *testing.T) {
 
 	result, err := readAppleDhcpdLeaseEntry(consumeAppleLeaseString(test_1))
 	if err != nil {
-		t.Errorf("error parsing entry: %v", err)
+		t.Errorf("error parsing entry: %s", err)
 	}
 	if result.ipAddress != expected_1["ipAddress"] {
 		t.Errorf("expected ipAddress %v, got %v", expected_1["ipAddress"], result.ipAddress)
@@ -930,7 +930,7 @@ func TestParserReadAppleDhcpdLeaseEntry(t *testing.T) {
 
 	result, err = readAppleDhcpdLeaseEntry(consumeAppleLeaseString(test_2))
 	if err != nil {
-		t.Errorf("error parsing entry: %v", err)
+		t.Errorf("error parsing entry: %s", err)
 	}
 	if result.ipAddress != expected_2["ipAddress"] {
 		t.Errorf("expected ipAddress %v, got %v", expected_2["ipAddress"], result.ipAddress)
@@ -1212,13 +1212,13 @@ func TestParserReadNetworingConfig(t *testing.T) {
 
 	f, err := os.Open(filepath.Join("testdata", "networking-example"))
 	if err != nil {
-		t.Fatalf("Unable to open networking-example sample: %v", err)
+		t.Fatalf("Unable to open networking-example sample: %s", err)
 	}
 	defer f.Close()
 
 	config, err := ReadNetworkingConfig(f)
 	if err != nil {
-		t.Fatalf("error parsing networking-example: %v", err)
+		t.Fatalf("error parsing networking-example: %s", err)
 	}
 
 	if vnet, ok := config.answer[1]; ok {

--- a/builder/vmware/common/run_config.go
+++ b/builder/vmware/common/run_config.go
@@ -6,6 +6,7 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
@@ -68,11 +69,11 @@ type RunConfig struct {
 func (c *RunConfig) Prepare(_ *interpolate.Context, driverConfig *DriverConfig) (warnings []string, errs []error) {
 	if c.VNCOverWebsocket {
 		if driverConfig.RemoteType == "" {
-			errs = append(errs, fmt.Errorf("'vnc_over_websocket' can only be used with remote hypervisor builds"))
+			errs = append(errs, errors.New("'vnc_over_websocket' can only be used with remote hypervisor builds"))
 			return
 		}
 		if c.VNCPortMin != 0 || c.VNCPortMax != 0 || c.VNCBindAddress != "" || c.VNCDisablePassword {
-			warnings = append(warnings, "[WARN] 'vnc_over_websocket' enabled, any other VNC configuration will be ignored.")
+			warnings = append(warnings, "[WARN] 'vnc_over_websocket' enabled; other VNC configurations will be ignored.")
 		}
 		return
 	}

--- a/builder/vmware/common/run_config_test.go
+++ b/builder/vmware/common/run_config_test.go
@@ -94,7 +94,7 @@ func TestRunConfig_Prepare(t *testing.T) {
 			},
 			driver:   &DriverConfig{RemoteType: "esx5"},
 			errs:     nil,
-			warnings: []string{"[WARN] 'vnc_over_websocket' enabled, any other VNC configuration will be ignored."},
+			warnings: []string{"[WARN] 'vnc_over_websocket' enabled; other VNC configurations will be ignored."},
 		},
 	}
 

--- a/builder/vmware/common/ssh.go
+++ b/builder/vmware/common/ssh.go
@@ -33,7 +33,7 @@ func CommHost(config *SSHConfig) func(multistep.StateBag) (string, error) {
 		hosts, err := driver.PotentialGuestIP(state)
 		if err != nil {
 			log.Printf("IP lookup failed: %s", err)
-			return "", fmt.Errorf("IP lookup failed: %s", err)
+			return "", fmt.Errorf("failed to lookup IP: %s", err)
 		}
 
 		if len(hosts) == 0 {

--- a/builder/vmware/common/step_clean_files.go
+++ b/builder/vmware/common/step_clean_files.go
@@ -32,7 +32,7 @@ func (StepCleanFiles) Run(ctx context.Context, state multistep.StateBag) multist
 	dir := state.Get("dir").(OutputDir)
 	ui := state.Get("ui").(packersdk.Ui)
 
-	ui.Say("Deleting unnecessary VMware files...")
+	ui.Say("Deleting unnecessary files...")
 	files, err := dir.ListFiles()
 	if err != nil {
 		state.Put("error", err)

--- a/builder/vmware/common/step_configure_vmx.go
+++ b/builder/vmware/common/step_configure_vmx.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"regexp"
@@ -37,7 +38,7 @@ func (s *StepConfigureVMX) Run(ctx context.Context, state multistep.StateBag) mu
 	vmxPath := state.Get("vmx_path").(string)
 	vmxData, err := ReadVMX(vmxPath)
 	if err != nil {
-		err := fmt.Errorf("error reading VMX file: %s", err)
+		err = fmt.Errorf("error reading VMX file: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
@@ -110,7 +111,7 @@ func (s *StepConfigureVMX) Run(ctx context.Context, state multistep.StateBag) mu
 	} else {
 		displayName, ok := vmxData["displayname"]
 		if !ok { // Packer converts key names to lowercase!
-			err := fmt.Errorf("error returning value of displayName from VMX data")
+			err := errors.New("error returning value of displayName from VMX data")
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt
@@ -122,7 +123,7 @@ func (s *StepConfigureVMX) Run(ctx context.Context, state multistep.StateBag) mu
 	// Set the extendedConfigFile setting for the .vmxf filename to the VMName
 	// if displayName is not set. This is needed so that when VMware creates
 	// the .vmxf file it matches the displayName if it is set. When just using
-	// the sisplayName if it was empty VMware would make a file named ".vmxf".
+	// the displayName if it was empty VMware would make a file named ".vmxf".
 	// The ".vmxf" file would not get deleted when the VM got deleted.
 	if s.DisplayName != "" {
 		vmxData["extendedconfigfile"] = fmt.Sprintf("%s.vmxf", s.DisplayName)
@@ -133,7 +134,7 @@ func (s *StepConfigureVMX) Run(ctx context.Context, state multistep.StateBag) mu
 	err = WriteVMX(vmxPath, vmxData)
 
 	if err != nil {
-		err := fmt.Errorf("error writing VMX file: %s", err)
+		err = fmt.Errorf("error writing VMX file: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/vmware/common/step_configure_vmx_test.go
+++ b/builder/vmware/common/step_configure_vmx_test.go
@@ -21,7 +21,7 @@ func testVMXFile(t *testing.T) string {
 	// displayName must always be set
 	err = WriteVMX(tf.Name(), map[string]string{"displayName": "PackerBuild"})
 	if err != nil {
-		t.Fatalf("error writing .vmx file: %v", err)
+		t.Fatalf("error writing .vmx file: %s", err)
 	}
 	tf.Close()
 

--- a/builder/vmware/common/step_configure_vnc.go
+++ b/builder/vmware/common/step_configure_vnc.go
@@ -86,7 +86,7 @@ func (s *StepConfigureVNC) Run(ctx context.Context, state multistep.StateBag) mu
 
 	vmxData, err := ReadVMX(vmxPath)
 	if err != nil {
-		err := fmt.Errorf("error reading VMX file: %s", err)
+		err = fmt.Errorf("error reading VMX file: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
@@ -103,6 +103,7 @@ func (s *StepConfigureVNC) Run(ctx context.Context, state multistep.StateBag) mu
 	vncBindAddress, vncPort, err := vncFinder.VNCAddress(ctx, s.VNCBindAddress, s.VNCPortMin, s.VNCPortMax)
 
 	if err != nil {
+		err = fmt.Errorf("error finding available VNC port: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
@@ -115,7 +116,7 @@ func (s *StepConfigureVNC) Run(ctx context.Context, state multistep.StateBag) mu
 	vncFinder.UpdateVMX(vncBindAddress, vncPassword, vncPort, vmxData)
 
 	if err := WriteVMX(vmxPath, vmxData); err != nil {
-		err := fmt.Errorf("error writing VMX data: %s", err)
+		err = fmt.Errorf("error writing VMX data: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
@@ -140,7 +141,7 @@ func (*StepConfigureVNC) UpdateVMX(address, password string, port int, data map[
 func (s *StepConfigureVNC) Cleanup(multistep.StateBag) {
 	if s.l != nil {
 		if err := s.l.Close(); err != nil {
-			log.Printf("failed to unlock port lockfile: %v", err)
+			log.Printf("failed to unlock port lockfile: %s", err)
 		}
 	}
 }

--- a/builder/vmware/common/step_create_disks.go
+++ b/builder/vmware/common/step_create_disks.go
@@ -28,7 +28,7 @@ func (s *StepCreateDisks) Run(ctx context.Context, state multistep.StateBag) mul
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packersdk.Ui)
 
-	ui.Say("Creating required virtual machine disks")
+	ui.Say("Creating virtual machine disks...")
 
 	// Users can configure disks at several locations in the template so
 	// first collate all the disk requirements

--- a/builder/vmware/common/step_export.go
+++ b/builder/vmware/common/step_export.go
@@ -80,7 +80,8 @@ func (s *StepExport) Run(ctx context.Context, state multistep.StateBag) multiste
 
 	err := os.MkdirAll(exportOutputPath, 0755)
 	if err != nil {
-		state.Put("error creating export directory", err)
+		err = fmt.Errorf("error creating export directory: %s", err)
+		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
 	}
@@ -99,7 +100,7 @@ func (s *StepExport) Run(ctx context.Context, state multistep.StateBag) multiste
 		// password that we can log the command to the UI for debugging.
 		ui_args, err := s.generateRemoteExportArgs(c, displayName, true, exportOutputPath)
 		if err != nil {
-			err := fmt.Errorf("error generating ovftool export args: %s", err)
+			err = fmt.Errorf("error generating ovftool export args: %s", err)
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt
@@ -110,7 +111,7 @@ func (s *StepExport) Run(ctx context.Context, state multistep.StateBag) multiste
 		// password, so we can actually use it.
 		args, err = s.generateRemoteExportArgs(c, displayName, false, exportOutputPath)
 		if err != nil {
-			err := fmt.Errorf("error generating ovftool export args: %s", err)
+			err = fmt.Errorf("error generating ovftool export args: %s", err)
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt
@@ -128,7 +129,7 @@ func (s *StepExport) Run(ctx context.Context, state multistep.StateBag) multiste
 	}
 
 	if err := driver.Export(args); err != nil {
-		err := fmt.Errorf("error performing ovftool export: %s", err)
+		err = fmt.Errorf("error performing ovftool export: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/vmware/common/step_http_ip_discover.go
+++ b/builder/vmware/common/step_http_ip_discover.go
@@ -24,7 +24,7 @@ func (s *StepHTTPIPDiscover) Run(ctx context.Context, state multistep.StateBag) 
 	// Determine the host IP
 	hostIP, err := driver.HostIP(state)
 	if err != nil {
-		err := fmt.Errorf("error detecting host IP: %s", err)
+		err = fmt.Errorf("error detecting host IP: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/vmware/common/step_remote_upload.go
+++ b/builder/vmware/common/step_remote_upload.go
@@ -39,7 +39,7 @@ func (s *StepRemoteUpload) Run(ctx context.Context, state multistep.StateBag) mu
 		remotePath := esx5.CachePath(path)
 
 		if esx5.VerifyChecksum(s.Checksum, remotePath) {
-			ui.Say("Remote cache was verified skipping remote upload...")
+			ui.Say("Remote cache verified; skipping remote upload...")
 			state.Put(s.Key, remotePath)
 			return multistep.ActionContinue
 		}
@@ -50,7 +50,7 @@ func (s *StepRemoteUpload) Run(ctx context.Context, state multistep.StateBag) mu
 	log.Printf("Remote uploading: %s", path)
 	newPath, err := remote.UploadISO(path, s.Checksum, ui)
 	if err != nil {
-		err := fmt.Errorf("error uploading file: %s", err)
+		err = fmt.Errorf("error uploading file: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/vmware/common/step_suppress_messages.go
+++ b/builder/vmware/common/step_suppress_messages.go
@@ -22,7 +22,7 @@ func (s *StepSuppressMessages) Run(ctx context.Context, state multistep.StateBag
 
 	log.Println("Suppressing messages in VMX")
 	if err := driver.SuppressMessages(vmxPath); err != nil {
-		err := fmt.Errorf("error suppressing messages: %s", err)
+		err = fmt.Errorf("error suppressing messages: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/vmware/common/step_upload_tools.go
+++ b/builder/vmware/common/step_upload_tools.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -33,7 +34,7 @@ func (c *StepUploadTools) Run(ctx context.Context, state multistep.StateBag) mul
 
 	if c.RemoteType == "esx5" {
 		if err := driver.ToolsInstall(); err != nil {
-			state.Put("error", fmt.Errorf("unable to mount VMware Tools ISO, check the 'guest_os_type'"))
+			state.Put("error", errors.New("unable to mount VMware Tools ISO, check the 'guest_os_type'"))
 		}
 		return multistep.ActionContinue
 	}
@@ -42,7 +43,7 @@ func (c *StepUploadTools) Run(ctx context.Context, state multistep.StateBag) mul
 	tools_source := state.Get("tools_upload_source").(string)
 	ui := state.Get("ui").(packersdk.Ui)
 
-	ui.Say(fmt.Sprintf("Uploading VMware Tools (%s)...", c.ToolsUploadFlavor))
+	ui.Sayf("Uploading VMware Tools (%s)...", c.ToolsUploadFlavor)
 	f, err := os.Open(tools_source)
 	if err != nil {
 		state.Put("error", fmt.Errorf("error opening VMware Tools ISO: %s", err))
@@ -55,14 +56,14 @@ func (c *StepUploadTools) Run(ctx context.Context, state multistep.StateBag) mul
 	}
 	c.ToolsUploadPath, err = interpolate.Render(c.ToolsUploadPath, &c.Ctx)
 	if err != nil {
-		err := fmt.Errorf("error preparing upload path: %s", err)
+		err = fmt.Errorf("error preparing upload path: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
 	}
 
 	if err := comm.Upload(c.ToolsUploadPath, f, nil); err != nil {
-		err := fmt.Errorf("error uploading vmware tools: %s", err)
+		err = fmt.Errorf("error uploading vmware tools: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/vmware/common/step_upload_vmx.go
+++ b/builder/vmware/common/step_upload_vmx.go
@@ -33,7 +33,9 @@ func (c *StepUploadVMX) Run(ctx context.Context, state multistep.StateBag) multi
 			}
 		}
 		if err := remoteDriver.ReloadVM(); err != nil {
-			ui.Error(fmt.Sprintf("error reloading virtual machine: %s", err))
+			err = fmt.Errorf("error reloading virtual machine: %s", err)
+			state.Put("error", err)
+			ui.Errorf(err.Error())
 		}
 	}
 

--- a/builder/vmware/common/step_vnc_boot_command.go
+++ b/builder/vmware/common/step_vnc_boot_command.go
@@ -44,9 +44,9 @@ func (s *StepVNCBootCommand) Run(ctx context.Context, state multistep.StateBag) 
 	conn := state.Get("vnc_conn").(*vnc.ClientConn)
 	defer conn.Close()
 
-	// Wait the for the vm to boot.
+	// Wait the for the virtual machine to boot.
 	if int64(s.Config.BootWait) > 0 {
-		ui.Say(fmt.Sprintf("Waiting %s for boot...", s.Config.BootWait.String()))
+		ui.Sayf("Waiting %s for boot...", s.Config.BootWait.String())
 		select {
 		case <-time.After(s.Config.BootWait):
 			break
@@ -73,7 +73,7 @@ func (s *StepVNCBootCommand) Run(ctx context.Context, state multistep.StateBag) 
 	flatBootCommand := s.Config.FlatBootCommand()
 	command, err := interpolate.Render(flatBootCommand, &s.Ctx)
 	if err != nil {
-		err := fmt.Errorf("error preparing boot command: %s", err)
+		err = fmt.Errorf("error preparing boot command: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
@@ -88,7 +88,7 @@ func (s *StepVNCBootCommand) Run(ctx context.Context, state multistep.StateBag) 
 	}
 
 	if err := seq.Do(ctx, d); err != nil {
-		err := fmt.Errorf("error running boot command: %s", err)
+		err = fmt.Errorf("error running boot command: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/vmware/common/step_vnc_connect.go
+++ b/builder/vmware/common/step_vnc_connect.go
@@ -42,6 +42,7 @@ func (s *StepVNCConnect) Run(ctx context.Context, state multistep.StateBag) mult
 	}
 
 	if err != nil {
+		err = fmt.Errorf("error connecting to VNC: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
@@ -57,7 +58,7 @@ func (s *StepVNCConnect) ConnectVNCOverWebsocketClient(state multistep.StateBag)
 	// Acquire websocket ticket
 	ticket, err := driver.AcquireVNCOverWebsocketTicket()
 	if err != nil {
-		err := fmt.Errorf("error acquiring VNC over websocket ticket: %s", err)
+		err = fmt.Errorf("error acquiring VNC over websocket ticket: %s", err)
 		state.Put("error", err)
 		return nil, err
 	}
@@ -74,13 +75,13 @@ func (s *StepVNCConnect) ConnectVNCOverWebsocketClient(state multistep.StateBag)
 	log.Printf("[DEBUG] websocket url: %s", websocketUrl)
 	u, err := url.Parse(websocketUrl)
 	if err != nil {
-		err := fmt.Errorf("error parsing websocket url: %s", err)
+		err = fmt.Errorf("error parsing websocket url: %s", err)
 		state.Put("error", err)
 		return nil, err
 	}
 	origin, err := url.Parse("http://localhost")
 	if err != nil {
-		err := fmt.Errorf("error parsing websocket origin url: %s", err)
+		err = fmt.Errorf("error parsing websocket origin url: %s", err)
 		state.Put("error", err)
 		return nil, err
 	}

--- a/builder/vmware/common/tools_config.go
+++ b/builder/vmware/common/tools_config.go
@@ -6,6 +6,7 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -52,7 +53,7 @@ func (c *ToolsConfig) Prepare(ctx *interpolate.Context) []error {
 	var errs []error
 
 	if c.ToolsSourcePath != "" && c.ToolsUploadFlavor == "" {
-		errs = append(errs, fmt.Errorf("provide either 'tools_upload_flavor' or 'tools_upload_path' with 'tools_source_path'"))
+		errs = append(errs, errors.New("provide either 'tools_upload_flavor' or 'tools_upload_path' with 'tools_source_path'"))
 	} else if c.ToolsUploadFlavor != "" && !slices.Contains(allowedToolsFlavorValues, c.ToolsUploadFlavor) {
 		errs = append(errs, fmt.Errorf("invalid 'tools_upload_flavor' specified: %s; must be one of %s", c.ToolsUploadFlavor, strings.Join(allowedToolsFlavorValues, ", ")))
 	} else {

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -81,7 +81,7 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 		isoPath = relativeIsoPath
 	}
 
-	ui.Say("Building and writing VMX file")
+	ui.Say("Generating the .vmx file...")
 
 	vmxTemplate := DefaultVMXTemplate
 	if config.VMXTemplatePath != "" {
@@ -212,6 +212,7 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 		// read network map configuration into a NetworkNameMapper.
 		netmap, err := driver.NetworkMapper()
 		if err != nil {
+			err := fmt.Errorf("error reading network map configuration: %s", err)
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt
@@ -399,7 +400,7 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 	// Write the vmxData to the vmxPath
 	vmxPath := filepath.Join(vmxDir, config.VMName+".vmx")
 	if err := common.WriteVMX(vmxPath, vmxData); err != nil {
-		err := fmt.Errorf("error creating VMX file: %s", err)
+		err = fmt.Errorf("error creating VMX file: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/vmware/iso/step_create_vmx_test.go
+++ b/builder/vmware/iso/step_create_vmx_test.go
@@ -6,6 +6,7 @@ package iso
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -23,7 +24,7 @@ import (
 func createFloppyOutput(prefix string) (string, map[string]string, error) {
 	f, err := tmp.File(prefix)
 	if err != nil {
-		return "", map[string]string{}, fmt.Errorf("unable to create temp file")
+		return "", map[string]string{}, errors.New("unable to create temp file")
 	}
 	f.Close()
 
@@ -129,7 +130,7 @@ func TestAccStepCreateVmx_SerialFile(t *testing.T) {
 			}
 			_, err := os.Stat(tmpfile.Name())
 			if err != nil {
-				return fmt.Errorf("VMware builder did not create a file for serial port: %s", err)
+				return fmt.Errorf("Unable to create a file for serial port: %s", err)
 			}
 			return nil
 		},
@@ -182,7 +183,7 @@ func TestStepCreateVmx_SerialPort(t *testing.T) {
 			}
 			_, err := os.Stat(output)
 			if err != nil {
-				return fmt.Errorf("VMware builder did not create a file for serial port: %s", err)
+				return fmt.Errorf("Unable to create a file for serial port: %s", err)
 			}
 			// check the output
 			data, err := readFloppyOutput(output)
@@ -244,7 +245,7 @@ func TestStepCreateVmx_ParallelPort(t *testing.T) {
 			}
 			_, err := os.Stat(output)
 			if err != nil {
-				return fmt.Errorf("VMware builder did not create a file for serial port: %s", err)
+				return fmt.Errorf("Unable to create a file for serial port: %s", err)
 			}
 			// check the output
 			data, err := readFloppyOutput(output)
@@ -298,7 +299,7 @@ func TestStepCreateVmx_Usb(t *testing.T) {
 			}
 			_, err := os.Stat(output)
 			if err != nil {
-				return fmt.Errorf("VMware builder did not create a file for serial port: %s", err)
+				return fmt.Errorf("Unable to create a file for serial port: %s", err)
 			}
 			// check the output
 			data, err := readFloppyOutput(output)
@@ -358,7 +359,7 @@ func TestStepCreateVmx_Sound(t *testing.T) {
 			}
 			_, err := os.Stat(output)
 			if err != nil {
-				return fmt.Errorf("VMware builder did not create a file for serial port: %s", err)
+				return fmt.Errorf("Unable to create a file for serial port: %s", err)
 			}
 			// check the output
 			data, err := readFloppyOutput(output)

--- a/builder/vmware/vmx/config.go
+++ b/builder/vmware/vmx/config.go
@@ -7,6 +7,7 @@
 package vmx
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -37,7 +38,7 @@ type Config struct {
 	vmwcommon.DiskConfig           `mapstructure:",squash"`
 	// By default Packer creates a 'full' clone of the virtual machine
 	// specified in source_path. The resultant virtual machine is fully
-	// independant from the parent it was cloned from.
+	// independent from the parent it was cloned from.
 	//
 	// Setting linked to true instead causes Packer to create the virtual
 	// machine as a 'linked' clone. Linked clones use and require ongoing
@@ -111,7 +112,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
 	if c.RemoteType == "" {
 		if c.SourcePath == "" {
-			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("source_path is blank, but is required"))
+			errs = packersdk.MultiErrorAppend(errs, errors.New("'source_path' is blank, but is required"))
 		} else {
 			if _, err := os.Stat(c.SourcePath); err != nil {
 				errs = packersdk.MultiErrorAppend(errs,
@@ -145,7 +146,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	if c.RemoteType == "" && c.Format == "vmx" {
 		// if we're building locally and want a vmx, there's nothing to export.
 		// Set skip export flag here to keep the export step from attempting
-		// an unneded export
+		// an unneeded export
 		c.SkipExport = true
 	}
 

--- a/builder/vmware/vmx/step_clone_vmx.go
+++ b/builder/vmware/vmx/step_clone_vmx.go
@@ -38,7 +38,7 @@ func (s *StepCloneVMX) Run(ctx context.Context, state multistep.StateBag) multis
 
 	// Set the path we want for the new .vmx file and clone
 	vmxPath := filepath.Join(*s.OutputDir, s.VMName+".vmx")
-	ui.Say("Cloning source VM...")
+	ui.Say("Cloning source virtual machine...")
 	log.Printf("Cloning from: %s", s.Path)
 	log.Printf("Cloning to: %s", vmxPath)
 

--- a/docs-partials/builder/vmware/vmx/Config-not-required.mdx
+++ b/docs-partials/builder/vmware/vmx/Config-not-required.mdx
@@ -2,7 +2,7 @@
 
 - `linked` (bool) - By default Packer creates a 'full' clone of the virtual machine
   specified in source_path. The resultant virtual machine is fully
-  independant from the parent it was cloned from.
+  independent from the parent it was cloned from.
   
   Setting linked to true instead causes Packer to create the virtual
   machine as a 'linked' clone. Linked clones use and require ongoing


### PR DESCRIPTION
### Summary

- Update errors that don't require formatting to use `errors.New` instead of  `fmt.Errorf` to be more idiomatic.
- Updates UI errors that need formatting to `ui.Errorf` instead of `ui.Error(fmt.Sprintf(`
- Correct spelling mistakes in docs/comments.

### Testing

```console
packer-plugin-vmware on  chore/error-tech-debt [$!] via 🐹 v1.22.6 on 🐳 v26.1.3 (rancher-desktop) 
➜ go fmt ./...

packer-plugin-vmware on  chore/error-tech-debt [$!] via 🐹 v1.22.6 on 🐳 v26.1.3 (rancher-desktop) 
➜ make generate
2024/08/14 15:59:10 Copying "docs" to ".docs/"
2024/08/14 15:59:10 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vmware on  chore/error-tech-debt [$!] via 🐹 v1.22.6 on 🐳 v26.1.3 (rancher-desktop) took 6.3s 
➜ make build

packer-plugin-vmware on  chore/error-tech-debt [$!] via 🐹 v1.22.6 on 🐳 v26.1.3 (rancher-desktop) took 6.1s 
➜ make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 8.199s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    4.605s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    6.139s

packer-plugin-vmware on  chore/error-tech-debt [$!] via 🐹 v1.22.6 on 🐳 v26.1.3 (rancher-desktop) took 17.1s 
➜ make dev
packer plugins install --path packer-plugin-vmware "github.com/hashicorp/vmware"
Successfully installed plugin github.com/hashicorp/vmware from /Users/johnsonryan/Library/Mobile Documents/com~apple~CloudDocs/Code/Work/packer-plugin-vmware/packer-plugin-vmware to /Users/johnsonryan/.packer.d/plugins/github.com/hashicorp/vmware/packer-plugin-vmware_v1.1.1-dev_x5.0_darwin_amd64
```
