### PR TITLE
chore: fusion log messages

### DIFF
--- a/builder/vmware/common/driver_fusion.go
+++ b/builder/vmware/common/driver_fusion.go
@@ -207,13 +207,13 @@ func (d *FusionDriver) Clone(dst, src string, linked bool, snapshot string) erro
 
 func (d *FusionDriver) Verify() error {
 	version, err := d.getFusionVersion()
-	log.Printf("Checking %s version...", fusionProductName)
+	log.Printf("[INFO] Checking %s version...", fusionProductName)
 	if err != nil {
 		return fmt.Errorf("error getting %s version: %s", fusionProductName, err)
 	}
 
-	log.Printf("%s: %s", fusionProductName, version)
-	log.Printf("Checking %s paths...", fusionProductName)
+	log.Printf("[INFO] %s: %s", fusionProductName, version)
+	log.Printf("[INFO] Checking %s paths...", fusionProductName)
 
 	if _, err := os.Stat(d.AppPath); err != nil {
 		if os.IsNotExist(err) {
@@ -223,7 +223,7 @@ func (d *FusionDriver) Verify() error {
 		return err
 	}
 
-	log.Printf("- %s.app found at: %s", fusionProductName, d.AppPath)
+	log.Printf("[INFO] - %s.app found at: %s", fusionProductName, d.AppPath)
 
 	if _, err := os.Stat(d.vmxPath()); err != nil {
 		if os.IsNotExist(err) {
@@ -233,7 +233,7 @@ func (d *FusionDriver) Verify() error {
 		return err
 	}
 
-	log.Printf("- %s found at: %s", appVmx, d.vmxPath())
+	log.Printf("[INFO] - %s found at: %s", appVmx, d.vmxPath())
 
 	if _, err := os.Stat(d.vmrunPath()); err != nil {
 		if os.IsNotExist(err) {
@@ -243,7 +243,7 @@ func (d *FusionDriver) Verify() error {
 		return err
 	}
 
-	log.Printf("- %s found at: %s", appVmrun, d.vmrunPath())
+	log.Printf("[INFO] - %s found at: %s", appVmrun, d.vmrunPath())
 
 	if _, err := os.Stat(d.vdiskManagerPath()); err != nil {
 		if os.IsNotExist(err) {
@@ -252,7 +252,7 @@ func (d *FusionDriver) Verify() error {
 		return err
 	}
 
-	log.Printf("- %s found at: %s", appVdiskManager, d.vdiskManagerPath())
+	log.Printf("[INFO] - %s found at: %s", appVdiskManager, d.vdiskManagerPath())
 
 	libpath := d.libPath()
 
@@ -332,7 +332,7 @@ func (d *FusionDriver) getFusionVersion() (*version.Version, error) {
 
 	// Check for Tech Preview version.
 	if matches := technicalPreview.FindStringSubmatch(stderr.String()); matches != nil {
-		log.Printf("%s: e.x.p (Tech Preview)", fusionProductName)
+		log.Printf("[INFO] %s: e.x.p (Tech Preview)", fusionProductName)
 		return version.NewVersion("0.0.0-e.x.p")
 	}
 


### PR DESCRIPTION
### Description

Sets the information log messages in the Fusion driver to be prefaces with [INFO].

### Testing

```shell
packer-plugin-vmware on  chore/fusion-log-messages [$] via 🐹 v1.23.2 
➜ go fmt ./...

packer-plugin-vmware on  chore/fusion-log-messages [$] via 🐹 v1.23.2 
➜ make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 7.531s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    1.550s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    1.967s

packer-plugin-vmware on  chore/fusion-log-messages [$] via 🐹 v1.23.2 took 23.4s 
➜ make build

packer-plugin-vmware on  chore/fusion-log-messages [$] via 🐹 v1.23.2 took 5.0s 
➜ make dev
packer plugins install --path packer-plugin-vmware "github.com/hashicorp/vmware"
Successfully installed plugin github.com/hashicorp/vmware from /Users/ryan/Library/Mobile Documents/com~apple~CloudDocs/Code/Personal/packer-plugin-vmware/packer-plugin-vmware to /Users/ryan/.packer.d/plugins/github.com/hashicorp/vmware/packer-plugin-vmware_v1.1.1-dev_x5.0_darwin_arm64
```