### PR TITLE
fix: insecure host key

### DIFF
--- a/builder/vmware/common/driver_esxi.go
+++ b/builder/vmware/common/driver_esxi.go
@@ -37,6 +37,7 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/sdk-internals/communicator/ssh"
 	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 // EsxiDriver is a driver for building virtual machines on an ESXi host.
@@ -747,12 +748,18 @@ func (d *EsxiDriver) connect() error {
 		auth = append(auth, gossh.PublicKeys(signer))
 	}
 
+	knownHostsFile := filepath.Join(os.Getenv("HOME"), ".ssh", "known_hosts")
+	hostKeyCallback, err := knownhosts.New(knownHostsFile)
+	if err != nil {
+		return err
+	}
+
 	sshConfig := &ssh.Config{
 		Connection: ssh.ConnectFunc("tcp", address),
 		SSHConfig: &gossh.ClientConfig{
 			User:            d.Username,
 			Auth:            auth,
-			HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+			HostKeyCallback: hostKeyCallback,
 		},
 	}
 


### PR DESCRIPTION
### Summary

Enhancements to the `EsxiDriver` in the `builder/vmware/common/driver_esxi.go` file to improve security by using known host key verification. The most important changes involve importing the `knownhosts` package and updating the SSH connection configuration to use a known hosts file.

* Imported the `knownhosts` package to enable host key verification.
* Updated the `connect` function to use a known hosts file for host key verification instead of ignoring host keys.

### Reference

https://github.com/hashicorp/packer-plugin-vmware/security/code-scanning/7

