### PR TITLE
fix: ignore sa4010

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -636,6 +636,7 @@ func (d *VmwareDriver) HostAddress(state multistep.StateBag) (string, error) {
 			if strings.HasSuffix(strings.ToLower(intf.Name), device) {
 				return intf.HardwareAddr.String(), nil
 			}
+			//lint:ignore SA4010 result of append is not used here
 			names = append(names, intf.Name)
 		}
 	}


### PR DESCRIPTION
### Summary

This pull request includes a small change to the `builder/vmware/common/driver.go` file. The change adds a comment to ignore a specific lint warning.

* [`builder/vmware/common/driver.go`](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3R639): Added a comment to ignore the `SA4010` lint warning in the `HostAddress` function.
