### PR TITLE
fix: version checks

### DIFF
--- a/builder/vmware/common/driver_workstation10.go
+++ b/builder/vmware/common/driver_workstation10.go
@@ -50,7 +50,7 @@ func (d *Workstation10Driver) Verify() error {
 		return err
 	}
 
-	return workstationVerifyVersion(VMWARE_WS_VERSION)
+	return workstationVerifyVersion(workstationMinVersionObj.String())
 }
 
 func (d *Workstation10Driver) GetVmwareDriver() VmwareDriver {


### PR DESCRIPTION
### Summary

- Updates the version checks, using `hashicorp/go-version`.
- Updates log messages based on `INFO` or `WARN` context.
- Moves constants to the `driver.go` for easier maintenance.

### Tests

```sh
➜ make build

packer-plugin-vmware on  pr/262 via 🐹 v1.23.3 
➜ make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 7.042s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    2.665s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    3.531s

packer-plugin-vmware on  pr/262 via 🐹 v1.23.3 took 10.2s 
➜ make generate
2024/12/02 10:47:55 Copying "docs" to ".docs/"
2024/12/02 10:47:55 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...
```

Postive Tests: Min of 13.5.0; running 13.6.1.

```sh
2024/12/03 20:51:37 packer-plugin-vmware_v1.1.1-dev_x5.0_darwin_arm64 plugin: 2024/12/03 20:51:37 [INFO] Checking VMware Fusion version...
2024/12/03 20:51:37 packer-plugin-vmware_v1.1.1-dev_x5.0_darwin_arm64 plugin: 2024/12/03 20:51:37 [INFO] VMware Fusion: 13.6.1
2024/12/03 20:51:37 packer-plugin-vmware_v1.1.1-dev_x5.0_darwin_arm64 plugin: 2024/12/03 20:51:37 [INFO] Checking VMware Fusion paths...
2024/12/03 20:51:37 packer-plugin-vmware_v1.1.1-dev_x5.0_darwin_arm64 plugin: 2024/12/03 20:51:37 [INFO] - VMware Fusion.app found at: /Applications/VMware Fusion.app
2024/12/03 20:51:37 packer-plugin-vmware_v1.1.1-dev_x5.0_darwin_arm64 plugin: 2024/12/03 20:51:37 [INFO] - vmware-vmx found at: /Applications/VMware Fusion.app/Contents/Library/vmware-vmx
2024/12/03 20:51:37 packer-plugin-vmware_v1.1.1-dev_x5.0_darwin_arm64 plugin: 2024/12/03 20:51:37 [INFO] - vmrun found at: /Applications/VMware Fusion.app/Contents/Library/vmrun
2024/12/03 20:51:37 packer-plugin-vmware_v1.1.1-dev_x5.0_darwin_arm64 plugin: 2024/12/03 20:51:37 [INFO] - vmware-vdiskmanager found at: /Applications/VMware Fusion.app/Contents/Library/vmware-vdiskmanager
2024/12/03 20:51:37 packer-plugin-vmware_v1.1.1-dev_x5.0_darwin_arm64 plugin: 2024/12/03 20:51:37 Using driver *common.FusionDriver, Success: true
```

Negative Test: Min of 13.7.0 set as const; running 13.6.1.

```sh
packer build --force -var-file=photon-4.0-R2.pkrvars.hcl .
vmware-iso.vagrant-vmw: output will be in this color.

Build 'vmware-iso.vagrant-vmw' errored after 74 milliseconds 855 microseconds: failed creating driver : driver initialization failed. fix at least one driver to continue:
* [ERROR] Requires VMware Fusion 13.7.0 or later, 13.6.1 installed
```