### PR TITLE
refactor: workstation license check

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -27,8 +27,14 @@ const (
 	fusionMinVersion  = "13.5.0"
 
 	// VMware Workstation.
-	workstationProductName = "VMware Workstation"
-	workstationMinVersion  = "17.5.0"
+	workstationProductName      = "VMware Workstation"
+	workstationMinVersion       = "17.5.0"
+	workstationNoLicenseVersion = "17.6.2"
+	// Notes:
+	// Version 17.6.1 required a license key for commercial use but not for personal use.
+	// Reference: dub.sh/vmw-ws-personal-use
+	// Version 17.6.2 removed the license key requirement for commercial, educational, and personal use.
+	// References: dub.sh/vmw-ws-free, dub.sh/vmw-ws-176-rn
 
 	// VMware Workstation Player.
 	playerProductName         = "VMware Workstation Player"

--- a/builder/vmware/common/driver_workstation_unix_test.go
+++ b/builder/vmware/common/driver_workstation_unix_test.go
@@ -6,13 +6,125 @@
 package common
 
 import (
+	"errors"
+	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestWorkstationVersion_ws14(t *testing.T) {
-	input := `VMware Workstation Information:
-VMware Workstation 14.1.1 build-7528167 Release`
-	if err := workstationTestVersion("10", input); err != nil {
-		t.Fatal(err)
+var (
+	mockWorkstationVerifyVersionFunc func(string) error
+	mockGlobFunc                     func(string) ([]string, error)
+)
+
+func mockWorkstationVerifyVersion(workstationNoLicenseVersion string) error {
+	if mockWorkstationVerifyVersionFunc != nil {
+		return mockWorkstationVerifyVersionFunc(workstationNoLicenseVersion)
+	}
+	return nil
+}
+
+func mockGlob(pattern string) ([]string, error) {
+	if mockGlobFunc != nil {
+		return mockGlobFunc(pattern)
+	}
+	return nil, nil
+}
+
+func testableWorkstationCheckLicense(
+	workstationVerifyVersion func(string) error,
+	glob func(string) ([]string, error),
+) error {
+	err := workstationVerifyVersion(workstationNoLicenseVersion)
+	if err == nil {
+		return nil
+	}
+
+	var errVersionRequiresLicense = errors.New("installed version requires a license")
+	if err.Error() == errVersionRequiresLicense.Error() {
+		matches, globErr := glob("/etc/vmware/license-ws-*")
+		if globErr != nil {
+			return fmt.Errorf("error finding license: %w", globErr) // Propagate glob errors correctly
+		}
+		if len(matches) == 0 {
+			return errors.New("no license found")
+		}
+
+		return nil
+	}
+
+	return err
+}
+
+func TestWorkstationCheckLicense(t *testing.T) {
+	defer func() {
+		mockWorkstationVerifyVersionFunc = nil
+		mockGlobFunc = nil
+	}()
+
+	testCases := []struct {
+		name                          string
+		mockVerifyVersionResponse     error
+		mockGlobResponse              []string
+		mockGlobError                 error
+		expectedErrorMessageSubstring string
+	}{
+		{
+			name:                          fmt.Sprintf("version greater or equal to %s, skip license check", workstationNoLicenseVersion),
+			mockVerifyVersionResponse:     nil,
+			mockGlobResponse:              nil,
+			mockGlobError:                 nil,
+			expectedErrorMessageSubstring: "",
+		},
+		{
+			name:                          fmt.Sprintf("version lower than %s, license found", workstationNoLicenseVersion),
+			mockVerifyVersionResponse:     errors.New("installed version requires a license"),
+			mockGlobResponse:              []string{"/etc/vmware/license-ws-1234"},
+			mockGlobError:                 nil,
+			expectedErrorMessageSubstring: "",
+		},
+		{
+			name:                          fmt.Sprintf("version lower than %s, no license found", workstationNoLicenseVersion),
+			mockVerifyVersionResponse:     errors.New("installed version requires a license"),
+			mockGlobResponse:              []string{},
+			mockGlobError:                 nil,
+			expectedErrorMessageSubstring: "no license found",
+		},
+		{
+			name:                          "fail to detect version",
+			mockVerifyVersionResponse:     fmt.Errorf("failed to detect version"),
+			mockGlobResponse:              nil,
+			mockGlobError:                 nil,
+			expectedErrorMessageSubstring: "failed to detect version",
+		},
+		{
+			name:                          "error finding license file",
+			mockVerifyVersionResponse:     errors.New("installed version requires a license"),
+			mockGlobResponse:              nil,
+			mockGlobError:                 fmt.Errorf("error finding license file"),
+			expectedErrorMessageSubstring: "error finding license file",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockWorkstationVerifyVersionFunc = func(workstationNoLicenseVersion string) error {
+				return tc.mockVerifyVersionResponse
+			}
+
+			mockGlobFunc = func(pattern string) ([]string, error) {
+				return tc.mockGlobResponse, tc.mockGlobError
+			}
+
+			err := testableWorkstationCheckLicense(mockWorkstationVerifyVersion, mockGlob)
+
+			if tc.expectedErrorMessageSubstring == "" {
+				assert.NoError(t, err, tc.name)
+			} else {
+				assert.Error(t, err, tc.name)
+				assert.Contains(t, err.Error(), tc.expectedErrorMessageSubstring, tc.name)
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Summary

Refactors `workstationLicenseCheck` to enhance the handling of VMware Workstation license checks and improve test coverage. The most important changes include adding a new constant for a version that does not require a license, modifying the license check logic, and adding comprehensive unit tests for the updated logic.

Enhancements to license handling:

* [`builder/vmware/common/driver.go`](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3R32-R37): Added a new constant `workstationNoLicenseVersion` for version 17.6.2, which no longer requires a license for use - free for personal and commercia use - and provided notes and references for version changes.
* [`builder/vmware/common/driver_workstation_unix.go`](diffhunk://#diff-bbe4c1aa0333c30034450736a5adde34d68a010bf8e9d7569e684730124207acR24-R51): Updated the `workstationCheckLicense` function to skip the license check for versions greater than or equal to `workstationNoLicenseVersion` and added logging for different scenarios.

Improvements to test coverage:

* [`builder/vmware/common/driver_workstation_unix_test.go`](diffhunk://#diff-bac320f44c91e7b7445be2524ed882da6a7fcff4a1a3c9d0cfdad8664bcb8ffeR9-R128): Added mock functions and a new testable function `testableWorkstationCheckLicense` to facilitate unit testing. Implemented multiple test cases to cover various scenarios, including version checks and license file detection.

Resolves #242