### PR TITLE
chore(deps): bump github.com/go-jose/go-jose/v4 v4.0.1 to v4.0.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dylanmei/iso8601 v0.1.0 // indirect
 	github.com/fatih/color v1.16.0 // indirect
-	github.com/go-jose/go-jose/v4 v4.0.1 // indirect
+	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
-github.com/go-jose/go-jose/v4 v4.0.1 h1:QVEPDE3OluqXBQZDcnNvQrInro2h0e4eqNbnZSWqS6U=
-github.com/go-jose/go-jose/v4 v4.0.1/go.mod h1:WVf9LFMHh/QVrmqrOfqun0C45tMe3RoiKJMPvgWwLfY=
+github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=
+github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=


### PR DESCRIPTION
### Description

Bumps bump github.com/go-jose/go-jose/v4 v4.0.1 to v4.0.5.

### Reference

[CVE-2025-27144](https://github.com/hashicorp/packer-plugin-vmware/security/dependabot/33)

### Tests

```shell
packer-plugin-vmware on  chore(deps)/go-jose [!] via 🐹 v1.24.1 took 4.1s 
➜ go get -u github.com/go-jose/go-jose/v4
go: downloading golang.org/x/crypto v0.32.0
go: upgraded github.com/go-jose/go-jose/v4 v4.0.1 => v4.0.5
go: upgraded golang.org/x/crypto v0.31.0 => v0.36.0
go: upgraded golang.org/x/sys v0.28.0 => v0.31.0
go: upgraded golang.org/x/term v0.27.0 => v0.30.0

packer-plugin-vmware on  chore(deps)/go-jose [!] via 🐹 v1.24.1 took 4.1s 
➜ go mod tidy                            

packer-plugin-vmware on  chore(deps)/go-jose [!] via 🐹 v1.24.1 
➜ make build                             

packer-plugin-vmware on  chore(deps)/go-jose [!] via 🐹 v1.24.1 
➜ make dev                               
packer plugins install --path packer-plugin-vmware "github.com/hashicorp/vmware"
Successfully installed plugin github.com/hashicorp/vmware from /Users/johnsonryan/Downloads/packer-plugin-vmware/packer-plugin-vmware to /Users/johnsonryan/.packer.d/plugins/github.com/hashicorp/vmware/packer-plugin-vmware_v1.1.1-dev_x5.0_darwin_amd64

packer-plugin-vmware on  chore(deps)/go-jose [!] via 🐹 v1.24.1 took 5.2s 
➜ make test                              
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 7.335s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    2.093s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    3.024s
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
```
