### PR TITLE
refactor: use `strings.ReplaceAll`

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -279,8 +279,8 @@ func runAndLog(cmd *exec.Cmd) (string, string, error) {
 
 	// Replace these for Windows, we only want to deal with Unix
 	// style line endings.
-	returnStdout := strings.Replace(stdout.String(), "\r\n", "\n", -1)
-	returnStderr := strings.Replace(stderr.String(), "\r\n", "\n", -1)
+	returnStdout := strings.ReplaceAll(stdout.String(), "\r\n", "\n")
+	returnStderr := strings.ReplaceAll(stderr.String(), "\r\n", "\n")
 
 	return returnStdout, returnStderr, err
 }

--- a/builder/vmware/common/driver_esxi.go
+++ b/builder/vmware/common/driver_esxi.go
@@ -604,7 +604,7 @@ func (d *EsxiDriver) CommHost(state multistep.StateBag) (string, error) {
 	if v, ok := state.GetOk("display_name"); ok {
 		displayName = v.(string)
 	} else {
-		displayName = strings.Replace(d.VMName, " ", "_", -1)
+		displayName = strings.ReplaceAll(d.VMName, " ", "_")
 		log.Printf("No 'display_name' set; using 'vmname' %s "+
 			"to look for an IP address for SSH", displayName)
 	}

--- a/builder/vmware/common/driver_fusion.go
+++ b/builder/vmware/common/driver_fusion.go
@@ -131,7 +131,7 @@ func (d *FusionDriver) Stop(vmxPath string) error {
 func (d *FusionDriver) SuppressMessages(vmxPath string) error {
 	dir := filepath.Dir(vmxPath)
 	base := filepath.Base(vmxPath)
-	base = strings.Replace(base, ".vmx", "", -1)
+	base = strings.ReplaceAll(base, ".vmx", "")
 
 	plistPath := filepath.Join(dir, base+".plist")
 	return os.WriteFile(plistPath, []byte(fusionSuppressPlist), 0644)

--- a/builder/vmware/iso/step_create_vmx_test.go
+++ b/builder/vmware/iso/step_create_vmx_test.go
@@ -29,7 +29,7 @@ func createFloppyOutput(prefix string) (string, map[string]string, error) {
 	f.Close()
 
 	output := f.Name()
-	outputFile := strings.Replace(output, "\\", "\\\\", -1)
+	outputFile := strings.ReplaceAll(output, "\\", "\\\\")
 	vmxData := map[string]string{
 		"floppy0.present":        "TRUE",
 		"floppy0.fileType":       "file",


### PR DESCRIPTION
Refactors to use `strings.ReplaceAll` as it more clearly expresses the intent to replace all occurrences of the substring and is the idiomatic Go approach for this use case since Go 1.12.

