### PR TITLE
refactor: use switch cdromAdapterType

### DIFF
--- a/builder/vmware/common/step_configure_vmx.go
+++ b/builder/vmware/common/step_configure_vmx.go
@@ -199,11 +199,12 @@ func DefaultDiskAndCDROMTypes(diskAdapterType string, cdromAdapterType string) D
 	// Handle the cdrom adapter type. If the disk adapter type and the
 	//  cdrom adapter type are the same, then ensure that the cdrom is the
 	//  secondary device on whatever bus the disk adapter is on.
-	if cdromAdapterType == "" {
+	switch cdromAdapterType {
+	case "":
 		cdromAdapterType = diskData.CDROMType
-	} else if cdromAdapterType == diskAdapterType {
+	case diskAdapterType:
 		diskData.CDROMType_PrimarySecondary = "1"
-	} else {
+	default:
 		diskData.CDROMType_PrimarySecondary = "0"
 	}
 


### PR DESCRIPTION
Replace the if-else if-else block used to determine the value of `diskData.CDROMType_PrimarySecondary` based on `cdromAdapterType` with an equivalent switch statement.

The switch statement improves readability and is the more idiomatic Go construct when evaluating a single variable against multiple distinct conditions (empty string, matching `diskAdapterType`, or default).

This change preserves the original logic and behavior.
