### PR TITLE
refactor: simplify access to methods/fields via direct calls

### DIFF
--- a/builder/vmware/common/driver_fusion.go
+++ b/builder/vmware/common/driver_fusion.go
@@ -244,19 +244,19 @@ func (d *FusionDriver) Verify() error {
 
 	libpath := d.libPath()
 
-	d.VmwareDriver.DhcpLeasesPath = func(device string) string {
+	d.DhcpLeasesPath = func(device string) string {
 		return "/var/db/vmware/vmnet-dhcpd-" + device + ".leases"
 	}
 
-	d.VmwareDriver.DhcpConfPath = func(device string) string {
+	d.DhcpConfPath = func(device string) string {
 		return filepath.Join(libpath, device, "dhcpd.conf")
 	}
 
-	d.VmwareDriver.VmnetnatConfPath = func(device string) string {
+	d.VmnetnatConfPath = func(device string) string {
 		return filepath.Join(libpath, device, "nat.conf")
 	}
 
-	d.VmwareDriver.NetworkMapper = func() (NetworkNameMapper, error) {
+	d.NetworkMapper = func() (NetworkNameMapper, error) {
 		pathNetworking := filepath.Join(libpath, "networking")
 		if _, err := os.Stat(pathNetworking); err != nil {
 			return nil, fmt.Errorf("unable to locate networking configuration file: %s", pathNetworking)

--- a/builder/vmware/common/driver_player.go
+++ b/builder/vmware/common/driver_player.go
@@ -253,19 +253,19 @@ func (d *PlayerDriver) Verify() error {
 		}
 	}
 
-	d.VmwareDriver.DhcpLeasesPath = func(device string) string {
+	d.DhcpLeasesPath = func(device string) string {
 		return playerDhcpLeasesPath(device)
 	}
 
-	d.VmwareDriver.DhcpConfPath = func(device string) string {
+	d.DhcpConfPath = func(device string) string {
 		return playerDhcpConfPath(device)
 	}
 
-	d.VmwareDriver.VmnetnatConfPath = func(device string) string {
+	d.VmnetnatConfPath = func(device string) string {
 		return playerNatConfPath(device)
 	}
 
-	d.VmwareDriver.NetworkMapper = func() (NetworkNameMapper, error) {
+	d.NetworkMapper = func() (NetworkNameMapper, error) {
 		pathNetmap := playerNetmapConfPath()
 
 		if _, err := os.Stat(pathNetmap); err == nil {

--- a/builder/vmware/common/driver_workstation10.go
+++ b/builder/vmware/common/driver_workstation10.go
@@ -37,7 +37,7 @@ func (d *Workstation10Driver) Clone(dst, src string, linked bool, snapshot strin
 	if snapshot != "" {
 		args = append(args, "-snapshot", snapshot)
 	}
-	cmd := exec.Command(d.Workstation9Driver.VmrunPath, args...)
+	cmd := exec.Command(d.VmrunPath, args...)
 	if _, _, err := runAndLog(cmd); err != nil {
 		return err
 	}
@@ -54,5 +54,5 @@ func (d *Workstation10Driver) Verify() error {
 }
 
 func (d *Workstation10Driver) GetVmwareDriver() VmwareDriver {
-	return d.Workstation9Driver.VmwareDriver
+	return d.VmwareDriver
 }

--- a/builder/vmware/common/driver_workstation9.go
+++ b/builder/vmware/common/driver_workstation9.go
@@ -197,19 +197,19 @@ func (d *Workstation9Driver) Verify() error {
 	}
 
 	// Assigning the path callbacks to VmwareDriver
-	d.VmwareDriver.DhcpLeasesPath = func(device string) string {
+	d.DhcpLeasesPath = func(device string) string {
 		return workstationDhcpLeasesPath(device)
 	}
 
-	d.VmwareDriver.DhcpConfPath = func(device string) string {
+	d.DhcpConfPath = func(device string) string {
 		return workstationDhcpConfPath(device)
 	}
 
-	d.VmwareDriver.VmnetnatConfPath = func(device string) string {
+	d.VmnetnatConfPath = func(device string) string {
 		return workstationVmnetnatConfPath(device)
 	}
 
-	d.VmwareDriver.NetworkMapper = func() (NetworkNameMapper, error) {
+	d.NetworkMapper = func() (NetworkNameMapper, error) {
 		// Check if the network mapper configuration file exists.
 		mapper, err := checkNetmapConfExists()
 

--- a/builder/vmware/common/ssh.go
+++ b/builder/vmware/common/ssh.go
@@ -43,12 +43,12 @@ func CommHost(config *SSHConfig) func(multistep.StateBag) (string, error) {
 
 		var pAddr string
 		var pAuth *proxy.Auth
-		if config.Comm.SSH.SSHProxyHost != "" {
-			pAddr = fmt.Sprintf("%s:%d", config.Comm.SSH.SSHProxyHost, config.Comm.SSH.SSHProxyPort)
-			if config.Comm.SSH.SSHProxyUsername != "" {
+		if config.Comm.SSHProxyHost != "" {
+			pAddr = fmt.Sprintf("%s:%d", config.Comm.SSHProxyHost, config.Comm.SSHProxyPort)
+			if config.Comm.SSHProxyUsername != "" {
 				pAuth = new(proxy.Auth)
-				pAuth.User = config.Comm.SSH.SSHProxyUsername
-				pAuth.Password = config.Comm.SSH.SSHProxyPassword
+				pAuth.User = config.Comm.SSHProxyUsername
+				pAuth.Password = config.Comm.SSHProxyPassword
 			}
 		}
 

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -78,15 +78,15 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			SSHTemporaryKeyPair: b.config.Comm.SSHTemporaryKeyPair,
 		}),
 		&commonsteps.StepCreateFloppy{
-			Files:       b.config.FloppyConfig.FloppyFiles,
-			Directories: b.config.FloppyConfig.FloppyDirectories,
-			Content:     b.config.FloppyConfig.FloppyContent,
-			Label:       b.config.FloppyConfig.FloppyLabel,
+			Files:       b.config.FloppyFiles,
+			Directories: b.config.FloppyDirectories,
+			Content:     b.config.FloppyContent,
+			Label:       b.config.FloppyLabel,
 		},
 		&commonsteps.StepCreateCD{
-			Files:   b.config.CDConfig.CDFiles,
-			Content: b.config.CDConfig.CDContent,
-			Label:   b.config.CDConfig.CDLabel,
+			Files:   b.config.CDFiles,
+			Content: b.config.CDContent,
+			Label:   b.config.CDLabel,
 		},
 		&vmwcommon.StepRemoteUpload{
 			Key:       "floppy_path",
@@ -103,7 +103,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		&vmwcommon.StepRemoteUpload{
 			Key:       "iso_path",
 			Message:   "Uploading ISO to remote machine...",
-			DoCleanup: b.config.DriverConfig.CleanUpRemoteCache,
+			DoCleanup: b.config.CleanUpRemoteCache,
 			Checksum:  b.config.ISOChecksum,
 		},
 		&vmwcommon.StepCreateDisks{
@@ -155,9 +155,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Comm:   &b.config.Comm,
 		},
 		&communicator.StepConnect{
-			Config:    &b.config.SSHConfig.Comm,
+			Config:    &b.config.Comm,
 			Host:      driver.CommHost,
-			SSHConfig: b.config.SSHConfig.Comm.SSHConfigFunc(),
+			SSHConfig: b.config.Comm.SSHConfigFunc(),
 		},
 		&vmwcommon.StepUploadTools{
 			RemoteType:        b.config.RemoteType,
@@ -167,7 +167,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 		&commonsteps.StepProvision{},
 		&commonsteps.StepCleanupTempKeys{
-			Comm: &b.config.SSHConfig.Comm,
+			Comm: &b.config.Comm,
 		},
 		&vmwcommon.StepShutdown{
 			Command: b.config.ShutdownCommand,
@@ -184,7 +184,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			DisplayName: b.config.VMXDisplayName,
 		},
 		&vmwcommon.StepCleanVMX{
-			RemoveEthernetInterfaces: b.config.VMXConfig.VMXRemoveEthernet,
+			RemoveEthernetInterfaces: b.config.VMXRemoveEthernet,
 			VNCEnabled:               !b.config.DisableVNC,
 		},
 		&vmwcommon.StepUploadVMX{
@@ -198,7 +198,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			SkipExport:     b.config.SkipExport,
 			VMName:         b.config.VMName,
 			OVFToolOptions: b.config.OVFToolOptions,
-			OutputDir:      &b.config.OutputConfig.OutputDir,
+			OutputDir:      &b.config.OutputDir,
 		},
 	}
 

--- a/builder/vmware/iso/builder_test.go
+++ b/builder/vmware/iso/builder_test.go
@@ -609,13 +609,13 @@ func TestBuilderPrepare_CommConfig(t *testing.T) {
 			t.Fatalf("should not have error: %s", err)
 		}
 
-		if b.config.SSHConfig.Comm.WinRMUser != "username" {
-			t.Errorf("bad winrm_username: %s", b.config.SSHConfig.Comm.WinRMUser)
+		if b.config.Comm.WinRMUser != "username" {
+			t.Errorf("bad winrm_username: %s", b.config.Comm.WinRMUser)
 		}
-		if b.config.SSHConfig.Comm.WinRMPassword != "password" {
-			t.Errorf("bad winrm_password: %s", b.config.SSHConfig.Comm.WinRMPassword)
+		if b.config.Comm.WinRMPassword != "password" {
+			t.Errorf("bad winrm_password: %s", b.config.Comm.WinRMPassword)
 		}
-		if host := b.config.SSHConfig.Comm.Host(); host != "1.2.3.4" {
+		if host := b.config.Comm.Host(); host != "1.2.3.4" {
 			t.Errorf("bad host: %s", host)
 		}
 	}
@@ -637,13 +637,13 @@ func TestBuilderPrepare_CommConfig(t *testing.T) {
 			t.Fatalf("should not have error: %s", err)
 		}
 
-		if b.config.SSHConfig.Comm.SSHUsername != "username" {
-			t.Errorf("bad ssh_username: %s", b.config.SSHConfig.Comm.SSHUsername)
+		if b.config.Comm.SSHUsername != "username" {
+			t.Errorf("bad ssh_username: %s", b.config.Comm.SSHUsername)
 		}
-		if b.config.SSHConfig.Comm.SSHPassword != "password" {
-			t.Errorf("bad ssh_password: %s", b.config.SSHConfig.Comm.SSHPassword)
+		if b.config.Comm.SSHPassword != "password" {
+			t.Errorf("bad ssh_password: %s", b.config.Comm.SSHPassword)
 		}
-		if host := b.config.SSHConfig.Comm.Host(); host != "1.2.3.4" {
+		if host := b.config.Comm.Host(); host != "1.2.3.4" {
 			t.Errorf("bad host: %s", host)
 		}
 	}

--- a/builder/vmware/iso/config.go
+++ b/builder/vmware/iso/config.go
@@ -175,8 +175,8 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		}
 	}
 
-	if c.HWConfig.Network == "" {
-		c.HWConfig.Network = "nat"
+	if c.Network == "" {
+		c.Network = "nat"
 	}
 
 	if c.Format == "" {
@@ -201,7 +201,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		}
 	}
 
-	err = c.DriverConfig.Validate(c.SkipExport)
+	err = c.Validate(c.SkipExport)
 	if err != nil {
 		errs = packersdk.MultiErrorAppend(errs, err)
 	}

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -184,8 +184,8 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 		ISOPath:         isoPath,
 		Network_Adapter: "e1000",
 
-		Sound_Present: map[bool]string{true: "TRUE", false: "FALSE"}[config.HWConfig.Sound],
-		Usb_Present:   map[bool]string{true: "TRUE", false: "FALSE"}[config.HWConfig.USB],
+		Sound_Present: map[bool]string{true: "TRUE", false: "FALSE"}[config.Sound],
+		Usb_Present:   map[bool]string{true: "TRUE", false: "FALSE"}[config.USB],
 
 		Serial_Present:   "FALSE",
 		Parallel_Present: "FALSE",
@@ -201,15 +201,15 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 	state.Put("temporaryDevices", tmpBuildDevices)
 
 	/// Assign the network adapter type into the template if one was specified.
-	network_adapter := strings.ToLower(config.HWConfig.NetworkAdapterType)
+	network_adapter := strings.ToLower(config.NetworkAdapterType)
 	if network_adapter != "" {
 		templateData.Network_Adapter = network_adapter
 	}
 
 	/// Check the network type that the user specified
-	network := config.HWConfig.Network
-	if config.HWConfig.NetworkName != "" {
-		templateData.Network_Name = config.HWConfig.NetworkName
+	network := config.Network
+	if config.NetworkName != "" {
+		templateData.Network_Name = config.NetworkName
 	}
 	driver := state.Get("driver").(common.Driver).GetVmwareDriver()
 
@@ -257,11 +257,11 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 	state.Put("vmnetwork", network)
 
 	// check if serial port has been configured
-	if !config.HWConfig.HasSerial() {
+	if !config.HasSerial() {
 		templateData.Serial_Present = "FALSE"
 	} else {
 		// FIXME
-		serial, err := config.HWConfig.ReadSerial()
+		serial, err := config.ReadSerial()
 		if err != nil {
 			err := fmt.Errorf("error processing VMX template: %s", err)
 			state.Put("error", err)
@@ -276,24 +276,24 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 		templateData.Serial_Host = ""
 		templateData.Serial_Auto = "FALSE"
 
-		switch config.HWConfig.Firmware {
+		switch config.Firmware {
 		case common.FirmwareTypeBios:
 			templateData.Firmware = common.FirmwareTypeBios
 		case common.FirmwareTypeUEFI, common.FirmwareTypeUEFISecure:
 			templateData.Firmware = common.FirmwareTypeUEFI
-			if config.HWConfig.Firmware == common.FirmwareTypeUEFISecure {
+			if config.Firmware == common.FirmwareTypeUEFISecure {
 				templateData.SecureBoot = "TRUE"
 			}
 		}
 
 		// Set the number of cpus if it was specified
-		if config.HWConfig.CpuCount > 0 {
-			templateData.CpuCount = strconv.Itoa(config.HWConfig.CpuCount)
+		if config.CpuCount > 0 {
+			templateData.CpuCount = strconv.Itoa(config.CpuCount)
 		}
 
 		// Apply the memory size that was specified
-		if config.HWConfig.MemorySize > 0 {
-			templateData.MemorySize = strconv.Itoa(config.HWConfig.MemorySize)
+		if config.MemorySize > 0 {
+			templateData.MemorySize = strconv.Itoa(config.MemorySize)
 		} else {
 			templateData.MemorySize = "512"
 		}
@@ -327,11 +327,11 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 	}
 
 	/// check if parallel port has been configured
-	if !config.HWConfig.HasParallel() {
+	if !config.HasParallel() {
 		templateData.Parallel_Present = "FALSE"
 	} else {
 		// FIXME
-		parallel, err := config.HWConfig.ReadParallel()
+		parallel, err := config.ReadParallel()
 		if err != nil {
 			err := fmt.Errorf("error processing VMX template: %s", err)
 			state.Put("error", err)
@@ -399,8 +399,8 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 	}
 
 	// If some number of cores were specified, then update "cpuid.coresPerSocket" with the requested value
-	if config.HWConfig.CoreCount > 0 {
-		vmxData["cpuid.corespersocket"] = strconv.Itoa(config.HWConfig.CoreCount)
+	if config.CoreCount > 0 {
+		vmxData["cpuid.corespersocket"] = strconv.Itoa(config.CoreCount)
 	}
 
 	// Write the vmxData to the vmxPath

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -76,15 +76,15 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			SSHTemporaryKeyPair: b.config.Comm.SSHTemporaryKeyPair,
 		}),
 		&commonsteps.StepCreateFloppy{
-			Files:       b.config.FloppyConfig.FloppyFiles,
-			Directories: b.config.FloppyConfig.FloppyDirectories,
-			Content:     b.config.FloppyConfig.FloppyContent,
-			Label:       b.config.FloppyConfig.FloppyLabel,
+			Files:       b.config.FloppyFiles,
+			Directories: b.config.FloppyDirectories,
+			Content:     b.config.FloppyContent,
+			Label:       b.config.FloppyLabel,
 		},
 		&commonsteps.StepCreateCD{
-			Files:   b.config.CDConfig.CDFiles,
-			Content: b.config.CDConfig.CDContent,
-			Label:   b.config.CDConfig.CDLabel,
+			Files:   b.config.CDFiles,
+			Content: b.config.CDContent,
+			Label:   b.config.CDLabel,
 		},
 		&vmwcommon.StepRemoteUpload{
 			Key:       "floppy_path",
@@ -150,9 +150,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Comm:   &b.config.Comm,
 		},
 		&communicator.StepConnect{
-			Config:    &b.config.SSHConfig.Comm,
+			Config:    &b.config.Comm,
 			Host:      driver.CommHost,
-			SSHConfig: b.config.SSHConfig.Comm.SSHConfigFunc(),
+			SSHConfig: b.config.Comm.SSHConfigFunc(),
 		},
 		&vmwcommon.StepUploadTools{
 			RemoteType:        b.config.RemoteType,
@@ -162,7 +162,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 		&commonsteps.StepProvision{},
 		&commonsteps.StepCleanupTempKeys{
-			Comm: &b.config.SSHConfig.Comm,
+			Comm: &b.config.Comm,
 		},
 		&vmwcommon.StepShutdown{
 			Command: b.config.ShutdownCommand,
@@ -179,7 +179,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			DisplayName: b.config.VMXDisplayName,
 		},
 		&vmwcommon.StepCleanVMX{
-			RemoveEthernetInterfaces: b.config.VMXConfig.VMXRemoveEthernet,
+			RemoveEthernetInterfaces: b.config.VMXRemoveEthernet,
 			VNCEnabled:               !b.config.DisableVNC,
 		},
 		&vmwcommon.StepUploadVMX{
@@ -193,7 +193,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			SkipExport:     b.config.SkipExport,
 			VMName:         b.config.VMName,
 			OVFToolOptions: b.config.OVFToolOptions,
-			OutputDir:      &b.config.OutputConfig.OutputDir,
+			OutputDir:      &b.config.OutputDir,
 		},
 	}
 

--- a/builder/vmware/vmx/builder_test.go
+++ b/builder/vmware/vmx/builder_test.go
@@ -81,7 +81,7 @@ func TestBuilderPrepare_CDContent(t *testing.T) {
 		t.Fatalf("using cd_content should just work")
 	}
 
-	if len(b.config.CDConfig.CDContent) == 0 {
+	if len(b.config.CDContent) == 0 {
 		t.Fatalf("cd_content is empty")
 	}
 

--- a/builder/vmware/vmx/config.go
+++ b/builder/vmware/vmx/config.go
@@ -150,7 +150,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		c.SkipExport = true
 	}
 
-	err = c.DriverConfig.Validate(c.SkipExport)
+	err = c.Validate(c.SkipExport)
 	if err != nil {
 		errs = packersdk.MultiErrorAppend(errs, err)
 	}


### PR DESCRIPTION
Refactored multiple instances where methods or fields were accessed through an intermediate field. These have been simplified to use direct access where applicable.

```shell
~/Downloads/packer-plugin-vmware git:[refactor/simplify-intermediate-access]
make generate
2025/04/27 20:53:09 Copying "docs" to ".docs/"
2025/04/27 20:53:09 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

~/Downloads/packer-plugin-vmware git:[refactor/simplify-intermediate-access]
make dev
packer plugins install --path packer-plugin-vmware "github.com/hashicorp/vmware"
Successfully installed plugin github.com/hashicorp/vmware from /Users/johnsonryan/Downloads/packer-plugin-vmware/packer-plugin-vmware to /Users/johnsonryan/.packer.d/plugins/github.com/hashicorp/vmware/packer-plugin-vmware_v1.1.1-dev_x5.0_darwin_amd64

~/Downloads/packer-plugin-vmware git:[refactor/simplify-intermediate-access]
make build

~/Downloads/packer-plugin-vmware git:[refactor/simplify-intermediate-access]
make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 7.175s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    3.584s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    2.677s
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
```