### PR TITLE
refactor: replace `foo += 1` with `foo++`

### DIFF
--- a/builder/vmware/common/driver_mock.go
+++ b/builder/vmware/common/driver_mock.go
@@ -114,11 +114,12 @@ type NetworkMapperMock struct {
 }
 
 func (m *NetworkMapperMock) NameIntoDevices(name string) ([]string, error) {
-	m.NameIntoDeviceCalled += 1
+	m.NameIntoDeviceCalled++
 	return make([]string, 0), nil
 }
+
 func (m *NetworkMapperMock) DeviceIntoName(device string) (string, error) {
-	m.DeviceIntoNameCalled += 1
+	m.DeviceIntoNameCalled++
 	return "", nil
 }
 

--- a/builder/vmware/common/driver_parser.go
+++ b/builder/vmware/common/driver_parser.go
@@ -2404,7 +2404,7 @@ func ReadDhcpdLeaseEntries(fd *os.File) ([]dhcpLeaseEntry, error) {
 	errors := make([]error, 0)
 
 	// Consume dhcpd lease entries from the channel until we just plain run out.
-	for i := 0; ; i += 1 {
+	for i := 0; ; i++ {
 		if entry, err := readDhcpdLeaseEntry(wch); entry == nil {
 			// If our entry is nil, then we've run out of input and finished
 			// parsing the file to completion.

--- a/builder/vmware/common/driver_parser_test.go
+++ b/builder/vmware/common/driver_parser_test.go
@@ -1082,7 +1082,7 @@ func TestParserTokenizeNetworkingConfig(t *testing.T) {
 		[]string{"newline-less"},
 	}
 
-	for testnum := 0; testnum < len(tests); testnum += 1 {
+	for testnum := 0; testnum < len(tests); testnum++ {
 		inCh := consumeString(tests[testnum])
 		outCh := tokenizeNetworkingConfig(inCh)
 		result := collectIntoStringList(outCh)
@@ -1094,7 +1094,7 @@ func TestParserTokenizeNetworkingConfig(t *testing.T) {
 		}
 
 		ok := true
-		for index := 0; index < len(expected); index += 1 {
+		for index := 0; index < len(expected); index++ {
 			if result[index] != expected[index] {
 				ok = false
 			}
@@ -1119,7 +1119,7 @@ func TestParserSplitNetworkingConfig(t *testing.T) {
 		[]string{"and", "begin", "with", "an", "empty", "string"},
 	}
 
-	for testnum := 0; testnum < len(tests); testnum += 1 {
+	for testnum := 0; testnum < len(tests); testnum++ {
 		inCh := consumeString(tests[testnum])
 		stringCh := tokenizeNetworkingConfig(inCh)
 		outCh := splitNetworkingConfig(stringCh)
@@ -1136,7 +1136,7 @@ func TestParserSplitNetworkingConfig(t *testing.T) {
 		}
 
 		ok := true
-		for index := 0; index < len(expected); index += 1 {
+		for index := 0; index < len(expected); index++ {
 			if result[index] != expected[index] {
 				ok = false
 			}
@@ -1155,14 +1155,14 @@ func TestParserParseNetworkingConfigVersion(t *testing.T) {
 		"VERSION=a,b",
 	}
 
-	for testnum := 0; testnum < len(success_tests); testnum += 1 {
+	for testnum := 0; testnum < len(success_tests); testnum++ {
 		test := []string{success_tests[testnum]}
 		if _, err := networkingReadVersion(test); err != nil {
 			t.Errorf("success-test %d parsing failed: %v", 1+testnum, err)
 		}
 	}
 
-	for testnum := 0; testnum < len(success_tests); testnum += 1 {
+	for testnum := 0; testnum < len(success_tests); testnum++ {
 		test := []string{failure_tests[testnum]}
 		if _, err := networkingReadVersion(test); err == nil {
 			t.Errorf("failure-test %d should have failed", 1+testnum)
@@ -1184,7 +1184,7 @@ func TestParserParseNetworkingConfigEntries(t *testing.T) {
 		"remove_nat_prefix 57005 /31",
 	}
 
-	for testnum := 0; testnum < len(tests); testnum += 1 {
+	for testnum := 0; testnum < len(tests); testnum++ {
 		test := strings.Split(tests[testnum], " ")
 		parser := NetworkingParserByCommand(test[0])
 		if parser == nil {

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -133,7 +133,7 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 			// Slot 7 is special and reserved, so we need to skip that index.
 			if i+1 == 7 {
 				incrementer = 2
-				unitSkip += 1
+				unitSkip++
 			}
 			ictx.Data = &additionalDiskTemplateData{
 				DiskUnit:   i + unitSkip,


### PR DESCRIPTION
### Description

Replaces `foo += 1` with `foo++`.

This change follows Go's idiomatic style by using the `++` operator instead of `+= 1` for incrementing variables. The `++` operator is more concise and is the standard way to increment loop counters in Go.
