### PR TITLE
refactor: remove superfluous else

### DIFF
--- a/builder/vmware/common/driver_parser.go
+++ b/builder/vmware/common/driver_parser.go
@@ -187,9 +187,8 @@ func parseTokenParameter(in chan string) tkParameter {
 		// Anything else we find are just operands we need to keep track of.
 		if strings.ContainsAny("{};", token) {
 			break
-		} else {
-			result.operand = append(result.operand, token)
 		}
+		result.operand = append(result.operand, token)
 	}
 	return result
 }
@@ -2174,17 +2173,15 @@ func consumeUntilSentinel(sentinel byte, in chan byte) (result []byte, ok bool) 
 	// byte has been reached. Consumed data is returned in `result, and if
 	// there's no more data to read, then `ok` will be false.
 	for ok = true; ; {
-		if by, success := <-in; !success {
+		by, success := <-in
+		if !success {
 			ok = false
 			break
-
-		} else if by == sentinel {
-			break
-
-		} else {
-			result = append(result, by)
-
 		}
+		if by == sentinel {
+			break
+		}
+		result = append(result, by)
 	}
 	return
 }
@@ -2220,10 +2217,8 @@ func consumeOpenClosePair(openByte, closeByte byte, in chan byte) ([]byte, chan 
 	for by := range in {
 		if by == openByte {
 			break
-
-		} else {
-			result = append(result, by)
 		}
+		result = append(result, by)
 	}
 
 	// Now we can feed input to our goroutine and a consumer can see what's

--- a/builder/vmware/common/driver_parser_test.go
+++ b/builder/vmware/common/driver_parser_test.go
@@ -37,11 +37,11 @@ func uncommentFromString(s string) string {
 
 	result := ""
 	for reading := true; reading; {
-		if item, ok := <-out; !ok {
+		item, ok := <-out
+		if !ok {
 			break
-		} else {
-			result += string(item)
 		}
+		result += string(item)
 	}
 	return result
 }
@@ -119,11 +119,11 @@ func tokenizeDhcpConfigFromString(s string) []string {
 
 	result := make([]string, 0)
 	for {
-		if item, ok := <-out; !ok {
+		item, ok := <-out
+		if !ok {
 			break
-		} else {
-			result = append(result, item)
 		}
+		result = append(result, item)
 	}
 	return result
 }


### PR DESCRIPTION
### Description

- Fix `revive` linter warnings related to `superfluous-else`.
- Move variable declarations to their own lines where needed.
- Simplify conditional blocks that had breaks followed by else clauses.
- Maintain identical functionality while improving code readability.
