### PR TITLE
chore: nolint gosec

### DIFF
--- a/builder/vmware/common/driver_workstation9.go
+++ b/builder/vmware/common/driver_workstation9.go
@@ -340,7 +340,7 @@ func generateNetmapConfig() (string, error) {
 		if err := os.MkdirAll(basePath, 0755); err != nil {
 			continue // Skip to the next path on error.
 		}
-		if err := os.WriteFile(path, netmapContent, 0644); err != nil {
+		if err := os.WriteFile(path, netmapContent, 0644); err != nil { //nolint:gosec
 			continue // Skip to the next path on error.
 		}
 

--- a/builder/vmware/common/ssh_config_test.go
+++ b/builder/vmware/common/ssh_config_test.go
@@ -85,6 +85,7 @@ func TestSSHConfigPrepare_SSHPrivateKey(t *testing.T) {
 	}
 }
 
+//nolint:gosec
 const testPem = `
 -----BEGIN RSA PRIVATE KEY-----
 MIIEpQIBAAKCAQEAxd4iamvrwRJvtNDGQSIbNvvIQN8imXTRWlRY62EvKov60vqu
@@ -114,3 +115,5 @@ eHLc1nkCgYEApm/motCTPN32nINZ+Vvywbv64ZD+gtpeMNP3CLrbe1X9O+H52AXa
 3bfQ8hKYcSnTfE0gPtLDnqCIxTocaGLSHeG3TH9fTw+dA8FvWpUztI4=
 -----END RSA PRIVATE KEY-----
 `
+
+//nolint:gosec

--- a/builder/vmware/common/step_clean_vmx_test.go
+++ b/builder/vmware/common/step_clean_vmx_test.go
@@ -38,7 +38,7 @@ func TestStepCleanVMX_floppyPath(t *testing.T) {
 
 	vmxPath := testVMXFile(t)
 	defer os.Remove(vmxPath)
-	if err := os.WriteFile(vmxPath, []byte(testVMXFloppyPath), 0644); err != nil {
+	if err := os.WriteFile(vmxPath, []byte(testVMXFloppyPath), 0644); err != nil { //nolint:gosec
 		t.Fatalf("err: %s", err)
 	}
 
@@ -91,7 +91,7 @@ func TestStepCleanVMX_isoPath(t *testing.T) {
 
 	vmxPath := testVMXFile(t)
 	defer os.Remove(vmxPath)
-	if err := os.WriteFile(vmxPath, []byte(testVMXISOPath), 0644); err != nil {
+	if err := os.WriteFile(vmxPath, []byte(testVMXISOPath), 0644); err != nil { //nolint:gosec
 		t.Fatalf("err: %s", err)
 	}
 
@@ -147,7 +147,7 @@ func TestStepCleanVMX_ethernet(t *testing.T) {
 
 	vmxPath := testVMXFile(t)
 	defer os.Remove(vmxPath)
-	if err := os.WriteFile(vmxPath, []byte(testVMXEthernet), 0644); err != nil {
+	if err := os.WriteFile(vmxPath, []byte(testVMXEthernet), 0644); err != nil { //nolint:gosec
 		t.Fatalf("err: %s", err)
 	}
 

--- a/builder/vmware/common/step_shutdown_test.go
+++ b/builder/vmware/common/step_shutdown_test.go
@@ -156,7 +156,7 @@ func TestStepShutdown_locks(t *testing.T) {
 
 	// Create some lock files
 	lockPath := filepath.Join(dir.dir, "nope.lck")
-	err := os.WriteFile(lockPath, []byte("foo"), 0644)
+	err := os.WriteFile(lockPath, []byte("foo"), 0644) //nolint:gosec
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/builder/vmware/vmx/step_clone_vmx_test.go
+++ b/builder/vmware/vmx/step_clone_vmx_test.go
@@ -52,13 +52,13 @@ func TestStepCloneVMX(t *testing.T) {
 
 	// Create the source
 	sourcePath := filepath.Join(td, "source.vmx")
-	if err := os.WriteFile(sourcePath, []byte(testCloneVMX), 0644); err != nil {
+	if err := os.WriteFile(sourcePath, []byte(testCloneVMX), 0644); err != nil { //nolint:gosec
 		t.Fatalf("err: %s", err)
 	}
 
 	// Create the dest because the mock driver won't
 	destPath := filepath.Join(td, "foo.vmx")
-	if err := os.WriteFile(destPath, []byte(testCloneVMX), 0644); err != nil {
+	if err := os.WriteFile(destPath, []byte(testCloneVMX), 0644); err != nil { //nolint:gosec
 		t.Fatalf("err: %s", err)
 	}
 


### PR DESCRIPTION
### Description

Adds `//nolint:gosec` for:

- Expected permission value for `.plist` file.
- Expected permission value for sample `.vmx` file for tests.
- Expected permission value for sample `.lock` file for tests.
- Sample PEM file for tests.

**Suppression of `gosec` linting warnings**:

* Added `//nolint:gosec` to `os.WriteFile` calls in `generateNetmapConfig` to bypass security linting for file permission issues. (`builder/vmware/common/driver_workstation9.go`, [builder/vmware/common/driver_workstation9.goL343-R343](diffhunk://#diff-9c1eac421dbc07a58019d9e0de8411cba0c97dbcd330a425d19d8585584100a7L343-R343))
* Added `//nolint:gosec` comments to `os.WriteFile` calls in the following test cases to suppress security warnings:
  - `TestStepCleanVMX_floppyPath` (`builder/vmware/common/step_clean_vmx_test.go`, [builder/vmware/common/step_clean_vmx_test.goL41-R41](diffhunk://#diff-34f31a2e4c1d0d058aa9a3fe83b452b118def808ee3f094849fd3fc56fd8502aL41-R41))
  - `TestStepCleanVMX_isoPath` (`builder/vmware/common/step_clean_vmx_test.go`, [builder/vmware/common/step_clean_vmx_test.goL94-R94](diffhunk://#diff-34f31a2e4c1d0d058aa9a3fe83b452b118def808ee3f094849fd3fc56fd8502aL94-R94))
  - `TestStepCleanVMX_ethernet` (`builder/vmware/common/step_clean_vmx_test.go`, [builder/vmware/common/step_clean_vmx_test.goL150-R150](diffhunk://#diff-34f31a2e4c1d0d058aa9a3fe83b452b118def808ee3f094849fd3fc56fd8502aL150-R150))
  - `TestStepShutdown_locks` (`builder/vmware/common/step_shutdown_test.go`, [builder/vmware/common/step_shutdown_test.goL159-R159](diffhunk://#diff-42809e850b9c60a443e24bd2812826e8160660b10883ce622fae09ecb677a5feL159-R159))
  - `TestStepCloneVMX` (`builder/vmware/vmx/step_clone_vmx_test.go`, [builder/vmware/vmx/step_clone_vmx_test.goL55-R61](diffhunk://#diff-2bd35c0c379181b31bd782ce66e981a8ba96a584721cfd6a5820177a1a2d3f48L55-R61))

**Test-specific changes**:

* Added `//nolint:gosec` comments to the `testPem` constant and after the RSA private key block in `TestSSHConfigPrepare_SSHPrivateKey` to suppress linting warnings for hardcoded credentials in test files. (`builder/vmware/common/ssh_config_test.go`, [[1]](diffhunk://#diff-865f95bdc6e4e21bcda83de4cc5bcb98759992890f4918e448f9110070980372R88) [[2]](diffhunk://#diff-865f95bdc6e4e21bcda83de4cc5bcb98759992890f4918e448f9110070980372R118-R119)

```shell
packer-plugin-vmware on  chore/nolint-gosec [!?] via 🐹 v1.24.3 took 11.6s 
➜ make build

packer-plugin-vmware on  chore/nolint-gosec [!?] via 🐹 v1.24.3 took 5.3s 
➜ make dev
packer plugins install --path packer-plugin-vmware "github.com/hashicorp/vmware"
Successfully installed plugin github.com/hashicorp/vmware from /Users/johnsonryan/Downloads/packer-plugin-vmware/packer-plugin-vmware to /Users/johnsonryan/.packer.d/plugins/github.com/hashicorp/vmware/packer-plugin-vmware_v1.1.1-dev_x5.0_darwin_amd64

packer-plugin-vmware on  chore/nolint-gosec [!?] via 🐹 v1.24.3 took 5.1s 
➜ make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 6.807s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    2.158s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    2.605s
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
```