### PR TITLE
chore: update golangci-lint to v2

### DIFF
--- a/.github/workflows/go-validate.yml
+++ b/.github/workflows/go-validate.yml
@@ -22,7 +22,7 @@ jobs:
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: 'Determine Go version'
         id: get-go-version
         run: |
@@ -34,8 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Go Mod Tidy
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
       - run: go mod tidy
@@ -45,13 +45,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Lint check
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
-      - uses: golangci/golangci-lint-action@82d40c283aeb1f2b6595839195e95c2d6a49081b # v5.0.0
+      - uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          version: v1.60.1
+          version: latest
           only-new-issues: true
   check-fmt:
     needs:
@@ -59,8 +59,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Gofmt check
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
       - run: |
@@ -77,8 +77,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Generate check
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
       - run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,45 +1,43 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
-# For more information about the golangci-lint configuration file, refer to:
-# https://golangci-lint.run/usage/configuration/
-
-issues:
-  exclude-rules:
-    # Exclude staticcheck for some rules.
-    - linters: [staticcheck]
-      text: "SA1006|SA1019|SA4006|SA4010|SA4017|SA5007|SA6005|SA9004"
-    # Exclude line length linter for generated files.
-    - linters: [lll]
-      source: "^//go:generate "
-    - linters:
-        - errcheck
-      path: ".*_test.go"
-
+---
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
     - unconvert
     - unused
-
-run:
-  concurrency: 4
-  timeout: 10m
-  exclude-files:
-    - ".*\\.hcl2spec\\.go$"
-
-output:
-  formats:
-    - format: colored-line-number
-
-linters-settings:
-  errcheck:
-    exclude-functions:
-      - "fmt:.*"
-      - "io:Close"
+  settings:
+    errcheck:
+      exclude-functions:
+        - fmt:.*
+        - io:Close
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - staticcheck
+        text: SA1006|SA1019|SA4006|SA4010|SA4017|SA5007|SA6005|SA9004
+      - linters:
+          - lll
+        source: '^//go:generate '
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
Updates `golangci-lint` to v2 (`latest`).

- Migrated the configuration.
- Updates the `golangci/golangci-lint-action` to v7 for interoperability.