### PR TITLE
refactor: simplify channel reading with range

### DIFF
--- a/builder/vmware/common/driver_parser_test.go
+++ b/builder/vmware/common/driver_parser_test.go
@@ -36,11 +36,7 @@ func uncommentFromString(s string) string {
 	out := uncomment(inCh)
 
 	result := ""
-	for reading := true; reading; {
-		item, ok := <-out
-		if !ok {
-			break
-		}
+	for item := range out {
 		result += string(item)
 	}
 	return result


### PR DESCRIPTION
`reading` would always be true. ut simplifying would leave it not used.

So, therefore refactored the loop using built-in `range` keyword for channels, which provides a more concise and readable way to iterate through channel values until the channel is closed.

```shell
~/Downloads/packer-plugin-vmware git:[refactor/simplify-channel-reading]
make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 6.901s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    2.241s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    2.737s
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
```