### PR TITLE
refactor: remove redundant type

### DIFF
--- a/builder/vmware/common/driver_parser_test.go
+++ b/builder/vmware/common/driver_parser_test.go
@@ -460,8 +460,8 @@ func TestParserReadNetworkMap(t *testing.T) {
 	}
 
 	expected_vmnet1 := [][]string{
-		[]string{"device", "vmnet1"},
-		[]string{"name", "HostOnly"},
+		{"device", "vmnet1"},
+		{"name", "HostOnly"},
 	}
 	for _, item := range netmap {
 		if item["device"] != "vmnet1" {
@@ -477,8 +477,8 @@ func TestParserReadNetworkMap(t *testing.T) {
 	}
 
 	expected_vmnet8 := [][]string{
-		[]string{"device", "vmnet8"},
-		[]string{"name", "NAT"},
+		{"device", "vmnet8"},
+		{"name", "NAT"},
 	}
 	for _, item := range netmap {
 		if item["device"] != "vmnet8" {
@@ -1077,9 +1077,9 @@ func TestParserTokenizeNetworkingConfig(t *testing.T) {
 		"       newline-less",
 	}
 	expects := [][]string{
-		[]string{"words", "words", "words"},
-		[]string{"newlines", "\n", "newlines", "\n", "newlines", "\n"},
-		[]string{"newline-less"},
+		{"words", "words", "words"},
+		{"newlines", "\n", "newlines", "\n", "newlines", "\n"},
+		{"newline-less"},
 	}
 
 	for testnum := 0; testnum < len(tests); testnum++ {
@@ -1113,10 +1113,10 @@ func TestParserSplitNetworkingConfig(t *testing.T) {
 		"\n\n\nand\nbegin\nwith\nan\nempty\nstring   ",
 	}
 	expects := [][]string{
-		[]string{"this is a story", "about some newlines"},
-		[]string{"that can begin and end with newlines"},
-		[]string{"in", "some", "cases", "it", "can", "end", "with", "an", "empty", "string"},
-		[]string{"and", "begin", "with", "an", "empty", "string"},
+		{"this is a story", "about some newlines"},
+		{"that can begin and end with newlines"},
+		{"in", "some", "cases", "it", "can", "end", "with", "an", "empty", "string"},
+		{"and", "begin", "with", "an", "empty", "string"},
 	}
 
 	for testnum := 0; testnum < len(tests); testnum++ {


### PR DESCRIPTION
Removes redundant type.

```shell
~/Downloads/packer-plugin-vmware git:[refactor/remove-redundant-type]
go fmt ./...

~/Downloads/packer-plugin-vmware git:[refactor/remove-redundant-type]
make dev
packer plugins install --path packer-plugin-vmware "github.com/hashicorp/vmware"
Successfully installed plugin github.com/hashicorp/vmware from /Users/johnsonryan/Downloads/packer-plugin-vmware/packer-plugin-vmware to /Users/johnsonryan/.packer.d/plugins/github.com/hashicorp/vmware/packer-plugin-vmware_v1.1.1-dev_x5.0_darwin_amd64

~/Downloads/packer-plugin-vmware git:[refactor/remove-redundant-type]
make build

~/Downloads/packer-plugin-vmware git:[refactor/remove-redundant-type]
make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 6.912s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    2.385s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    3.067s
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
```