### PR TITLE
chore: remove unused constant

### DIFF
--- a/builder/vmware/common/driver_workstation10.go
+++ b/builder/vmware/common/driver_workstation10.go
@@ -7,8 +7,6 @@ import (
 	"os/exec"
 )
 
-const VMWARE_WS_VERSION = "10"
-
 // Workstation10Driver is a driver that can run VMware Workstation 10
 // installations.
 


### PR DESCRIPTION
Removes unused constant: `VMWARE_WS_VERSION`.