### PR TITLE
refactor: variable overlap with used import

### DIFF
--- a/builder/vmware/common/driver_parser.go
+++ b/builder/vmware/common/driver_parser.go
@@ -2535,7 +2535,7 @@ func ReadAppleDhcpdLeaseEntries(fd *os.File) ([]appleDhcpLeaseEntry, error) {
 	wch := filterOutCharacters([]byte{'\r', '\v'}, uncommentedch)
 
 	result := make([]appleDhcpLeaseEntry, 0)
-	errors := make([]error, 0)
+	errorList := make([]error, 0)
 
 	// Consume apple dhcpd lease entries from the channel until we just plain run out.
 	for i := 0; ; i++ {
@@ -2548,7 +2548,7 @@ func ReadAppleDhcpdLeaseEntries(fd *os.File) ([]appleDhcpLeaseEntry, error) {
 			// If we received an error, then log it and keep track of it. This
 			// way we can warn the user later which entries we had issues with.
 			log.Printf("error parsing apple dhcpd lease entry #%d: %s", 1+i, err)
-			errors = append(errors, err)
+			errorList = append(errorList, err)
 
 		} else {
 			// If we've parsed an entry successfully, then aggregate it to
@@ -2558,8 +2558,8 @@ func ReadAppleDhcpdLeaseEntries(fd *os.File) ([]appleDhcpLeaseEntry, error) {
 	}
 
 	// If we received any errors then include alongside our results.
-	if len(errors) > 0 {
-		return result, fmt.Errorf("errors found while parsing apple dhcpd lease entries: %v", errors)
+	if len(errorList) > 0 {
+		return result, fmt.Errorf("errors found while parsing apple dhcpd lease entries: %v", errorList)
 	}
 	return result, nil
 }

--- a/builder/vmware/common/driver_parser_test.go
+++ b/builder/vmware/common/driver_parser_test.go
@@ -627,7 +627,7 @@ func TestParserCombinators(t *testing.T) {
 		t.Errorf("expected %#v, got %#v", expected_3_prefix, string(lease))
 	}
 
-	result_3 := []string{}
+	var result_3 []string
 	for reading := true; reading; {
 		item, ok := consumeUntilSentinel(';', itemch)
 		result_3 = append(result_3, string(item))


### PR DESCRIPTION
Renaming variable overlap with a used import, `errors`.

```shell
~/Downloads/packer-plugin-vmware git:[refactor/variable-overlap-with-used-import]
go fmt ./...

~/Downloads/packer-plugin-vmware git:[refactor/variable-overlap-with-used-import]
make dev
packer plugins install --path packer-plugin-vmware "github.com/hashicorp/vmware"
Successfully installed plugin github.com/hashicorp/vmware from /Users/johnsonryan/Downloads/packer-plugin-vmware/packer-plugin-vmware to /Users/johnsonryan/.packer.d/plugins/github.com/hashicorp/vmware/packer-plugin-vmware_v1.1.1-dev_x5.0_darwin_amd64

~/Downloads/packer-plugin-vmware git:[refactor/variable-overlap-with-used-import]
make build

~/Downloads/packer-plugin-vmware git:[refactor/variable-overlap-with-used-import]
make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 6.853s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    2.682s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    2.026s
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
````