### PR TITLE
refactor: replace type assertion on errors

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -243,7 +243,8 @@ func runAndLog(cmd *exec.Cmd) (string, string, error) {
 	stdoutString := strings.TrimSpace(stdout.String())
 	stderrString := strings.TrimSpace(stderr.String())
 
-	if _, ok := err.(*exec.ExitError); ok {
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) {
 		message := stderrString
 		if message == "" {
 			message = stdoutString

--- a/builder/vmware/common/driver_esxi.go
+++ b/builder/vmware/common/driver_esxi.go
@@ -548,8 +548,9 @@ func (d *EsxiDriver) VNCAddress(ctx context.Context, _ string, portMin, portMax 
 		l, err := net.DialTimeout("tcp", address, vncTimeout)
 
 		if err != nil {
-			if e, ok := err.(*net.OpError); ok {
-				if e.Timeout() {
+			var opError *net.OpError
+			if errors.As(err, &opError) {
+				if opError.Timeout() {
 					log.Printf("Timeout connecting to: %s (check firewall rules)", address)
 				} else {
 					vncPort = port


### PR DESCRIPTION
Replaces type assertion on errors with a call to `errors.As`.

The preferred way for checking for a specific error type is to use the `errors.As` function from the standard library as this function traverses the chain of the wrapped errors while checking for a specific error type.

```shell
~/Downloads/packer-plugin-vmware git:[refactor/replaces-type-assertion]
go fmt ./...

~/Downloads/packer-plugin-vmware git:[refactor/replaces-type-assertion]
make dev
packer plugins install --path packer-plugin-vmware "github.com/hashicorp/vmware"
Successfully installed plugin github.com/hashicorp/vmware from /Users/johnsonryan/Downloads/packer-plugin-vmware/packer-plugin-vmware to /Users/johnsonryan/.packer.d/plugins/github.com/hashicorp/vmware/packer-plugin-vmware_v1.1.1-dev_x5.0_darwin_amd64

~/Downloads/packer-plugin-vmware git:[refactor/replaces-type-assertion]
make build

~/Downloads/packer-plugin-vmware git:[refactor/replaces-type-assertion]
make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 6.855s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    2.109s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    2.617s
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]

~/Downloads/packer-plugin-vmware git:[refactor/replaces-type-assertion]
golangci-lint run
0 issues.
```