### PR TITLE
refactor: replace type assertion on errors

### DIFF
--- a/builder/vmware/common/driver_esxi.go
+++ b/builder/vmware/common/driver_esxi.go
@@ -652,8 +652,9 @@ func (d *EsxiDriver) CommHost(state multistep.StateBag) (string, error) {
 		// one that has a route back.
 		conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", record["IPAddress"], port), 2*time.Second)
 		if err != nil {
-			if e, ok := err.(*net.OpError); ok {
-				if e.Timeout() {
+			var opError *net.OpError
+			if errors.As(err, &opError) {
+				if opError.Timeout() {
 					log.Printf("Timeout connecting to %s", record["IPAddress"])
 					continue
 				}


### PR DESCRIPTION
Replaces type assertion on errors with a call to `errors.As`.

The preferred way for checking for a specific error type is to use the `errors.As` function from the standard library as this function traverses the chain of the wrapped errors while checking for a specific error type.