### PR TITLE
refactor: remove deprecated `ui.Message`

### DIFF
--- a/builder/vmware/common/step_clean_files.go
+++ b/builder/vmware/common/step_clean_files.go
@@ -5,7 +5,6 @@ package common
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -43,7 +42,7 @@ func (StepCleanFiles) Run(ctx context.Context, state multistep.StateBag) multist
 		}
 
 		if !keep {
-			ui.Message(fmt.Sprintf("Deleting: %s", path))
+			ui.Sayf("Deleting: %s", path)
 			if err = dir.Remove(path); err != nil {
 				// Only report the error if the file still exists. We do this
 				// because sometimes the files naturally get removed on their

--- a/builder/vmware/common/step_compact_disk.go
+++ b/builder/vmware/common/step_compact_disk.go
@@ -6,8 +6,6 @@ package common
 import (
 	"context"
 	"fmt"
-	"log"
-
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 )
@@ -23,13 +21,13 @@ func (s StepCompactDisk) Run(ctx context.Context, state multistep.StateBag) mult
 	diskFullPaths := state.Get("disk_full_paths").([]string)
 
 	if s.Skip {
-		log.Println("Skipping disk compaction step...")
+		ui.Say("Skipping disk compaction...")
 		return multistep.ActionContinue
 	}
 
 	ui.Say("Compacting all attached virtual disks...")
 	for i, diskFullPath := range diskFullPaths {
-		ui.Message(fmt.Sprintf("Compacting virtual disk %d", i+1))
+		ui.Sayf("Compacting virtual disk %d", i+1)
 		if err := driver.CompactDisk(diskFullPath); err != nil {
 			state.Put("error", fmt.Errorf("error compacting disk: %s", err))
 			return multistep.ActionHalt

--- a/builder/vmware/common/step_export.go
+++ b/builder/vmware/common/step_export.go
@@ -105,8 +105,7 @@ func (s *StepExport) Run(ctx context.Context, state multistep.StateBag) multiste
 			ui.Error(err.Error())
 			return multistep.ActionHalt
 		}
-		ui.Message(fmt.Sprintf("Executing: %s %s", ovftool,
-			strings.Join(uiArgs, " ")))
+		ui.Sayf("Executing: %s %s", ovftool, strings.Join(uiArgs, " "))
 		// Re-run the generate command, this time without obfuscating the
 		// password, so we can actually use it.
 		args, err = s.generateRemoteExportArgs(c, displayName, false, exportOutputPath)
@@ -118,8 +117,7 @@ func (s *StepExport) Run(ctx context.Context, state multistep.StateBag) multiste
 		}
 	} else {
 		args, err = s.generateLocalExportArgs(exportOutputPath)
-		ui.Message(fmt.Sprintf("Executing: %s %s", ovftool,
-			strings.Join(uiArgs, " ")))
+		ui.Sayf("Executing: %s %s", ovftool, strings.Join(uiArgs, " "))
 	}
 	if err != nil {
 		err := fmt.Errorf("error generating ovftool export args: %s", err)

--- a/builder/vmware/common/step_output_dir.go
+++ b/builder/vmware/common/step_output_dir.go
@@ -82,7 +82,7 @@ func (s *StepOutputDir) Run(ctx context.Context, state multistep.StateBag) multi
 
 	if exists {
 		if s.Force {
-			ui.Message("Deleting previous output directory...")
+			ui.Say("Deleting previous output directory...")
 			_ = dir.RemoveAll()
 		} else {
 			state.Put("error", fmt.Errorf("output directory '%s' already exists", dir.String()))

--- a/builder/vmware/common/step_register.go
+++ b/builder/vmware/common/step_register.go
@@ -91,7 +91,7 @@ func (s *StepRegister) Cleanup(state multistep.StateBag) {
 
 		if err != nil {
 			ui.Errorf("error: %s", err)
-			ui.Message("Please perform the necessary manual operations to clean up the virtual machine.")
+			ui.Say("Automated cleanup unsuccessful. Manual intervention is required to remove the virtual machine instance.")
 			return
 		}
 	}

--- a/builder/vmware/common/step_run.go
+++ b/builder/vmware/common/step_run.go
@@ -41,16 +41,16 @@ func (s *StepRun) Run(ctx context.Context, state multistep.StateBag) multistep.S
 			vncPort := vncPortRaw.(int)
 			vncPassword := vncPasswordRaw.(string)
 
-			ui.Message(fmt.Sprintf(
+			ui.Sayf(
 				"The virtual machine will be run headless, without a GUI.\n"+
 					"To view the virtual machine console, connect using VNC:\n\n"+
 					"Endpoint: \"vnc://%s:%d\"\n"+
-					"Password: \"%s\"", vncIp, vncPort, vncPassword))
+					"Password: \"%s\"", vncIp, vncPort, vncPassword)
 		} else {
-			ui.Message(fmt.Sprintf(
+			ui.Say(
 				"The virtual machine will be run headless, without a GUI.\n" +
 					"If the build is not succeeding, enable the GUI to\n" +
-					"inspect the progress of the build."))
+					"inspect the progress of the build.")
 		}
 	}
 
@@ -88,7 +88,7 @@ func (s *StepRun) Cleanup(state multistep.StateBag) {
 			ui.Say("Stopping virtual machine...")
 			if err := driver.Stop(s.vmxPath); err != nil {
 				ui.Errorf("error stopping the virtual machine: %s", err)
-				ui.Message("Please perform the necessary manual operations to stop the virtual machine.")
+				ui.Say("Please perform the necessary manual operations to stop the virtual machine.")
 				return
 			}
 		}

--- a/builder/vmware/common/step_shutdown.go
+++ b/builder/vmware/common/step_shutdown.go
@@ -82,7 +82,7 @@ func (s *StepShutdown) Run(ctx context.Context, state multistep.StateBag) multis
 		}
 	}
 
-	ui.Message("Waiting for clean up...")
+	ui.Say("Waiting for clean up...")
 	lockRegex := regexp.MustCompile(`(?i)\.lck$`)
 	timer := time.After(120 * time.Second)
 LockWaitLoop:


### PR DESCRIPTION
Replaces the SDK-deprecated `ui.Message` with `ui.Say` and `ui.Sayf` as applicable.

```shell
~/Downloads/packer-plugin-vmware git:[refactor/remove-deprecated-ui.Message]
go fmt ./...

~/Downloads/packer-plugin-vmware git:[refactor/remove-deprecated-ui.Message]
make dev
packer plugins install --path packer-plugin-vmware "github.com/hashicorp/vmware"
Successfully installed plugin github.com/hashicorp/vmware from /Users/johnsonryan/Downloads/packer-plugin-vmware/packer-plugin-vmware to /Users/johnsonryan/.packer.d/plugins/github.com/hashicorp/vmware/packer-plugin-vmware_v1.1.1-dev_x5.0_darwin_amd64

~/Downloads/packer-plugin-vmware git:[refactor/remove-deprecated-ui.Message]
make build

~/Downloads/packer-plugin-vmware git:[refactor/remove-deprecated-ui.Message]
make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 6.915s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    1.701s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    2.235s
```