### PR TITLE
refactor: use `log.Fatal` for fatal error handling in `main`

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,11 +4,9 @@
 package main
 
 import (
-	"fmt"
-	"os"
+	"log"
 
 	"github.com/hashicorp/packer-plugin-sdk/plugin"
-
 	"github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso"
 	"github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx"
 	"github.com/hashicorp/packer-plugin-vmware/version"
@@ -21,7 +19,6 @@ func main() {
 	pps.SetVersion(version.PluginVersion)
 	err := pps.Run()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
+		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
Refactor fatal error handling in the main function to use `log.Fatal`.

Previously, fatal errors were handled by printing to os.Stderr using `fmt.Fprintln` followed by an explicit `os.Exit(1)`.This change replaces that pattern with a single call to `log.Fatal(err)`. This is more idiomatic Go, makes the code more concise, and leverages the standard log package's capabilities, such as automatic timestamping of the error message. The program's exit behavior (exiting with status 1 on fatal error) remains the same.

```shell
~/Downloads/packer-plugin-vmware git:[refactor/standardize-fatal-error-handling]
go fmt ./...

~/Downloads/packer-plugin-vmware git:[refactor/standardize-fatal-error-handling]
make dev
packer plugins install --path packer-plugin-vmware "github.com/hashicorp/vmware"
Successfully installed plugin github.com/hashicorp/vmware from /Users/johnsonryan/Downloads/packer-plugin-vmware/packer-plugin-vmware to /Users/johnsonryan/.packer.d/plugins/github.com/hashicorp/vmware/packer-plugin-vmware_v1.1.1-dev_x5.0_darwin_amd64

~/Downloads/packer-plugin-vmware git:[refactor/standardize-fatal-error-handling]
make build

~/Downloads/packer-plugin-vmware git:[refactor/standardize-fatal-error-handling]
make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 7.520s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    3.759s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    2.914s
```