### PR TITLE
chore: bump to v1.2.0-dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ package version
 import "github.com/hashicorp/packer-plugin-sdk/version"
 
 var (
-	Version           = "1.1.1"
+	Version           = "1.2.0"
 	VersionPrerelease = "dev"
 	VersionMetadata   = ""
 	PluginVersion     = version.NewPluginVersion(Version, VersionPrerelease, VersionMetadata)


### PR DESCRIPTION
Updates to v1.2.0-dev.

```shell
~/Downloads/packer-plugin-vmware git:[chore/prepare-v1.2.0-dev]
make build

~/Downloads/packer-plugin-vmware git:[chore/prepare-v1.2.0-dev]
make dev
packer plugins install --path packer-plugin-vmware "github.com/hashicorp/vmware"
Successfully installed plugin github.com/hashicorp/vmware from /Users/johnsonryan/Downloads/packer-plugin-vmware/packer-plugin-vmware to /Users/johnsonryan/.packer.d/plugins/github.com/hashicorp/vmware/packer-plugin-vmware_v1.2.0-dev_x5.0_darwin_amd64
```