### PR TITLE
refactor: update default hardware version

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -68,7 +68,7 @@ JSON Example:
 
 - `version` (int) - The virtual machine hardware version. Refer to [KB 315655](https://knowledge.broadcom.com/external/article?articleNumber=315655)
   for more information on supported virtual hardware versions.
-  Minimum is 13. Default is 19.
+  Minimum is 13. Default is 21.
 
 - `vm_name` (string) - The name of the virtual machine. This represents the name of the virtual
   machine `.vmx` configuration file without the file extension.

--- a/builder/vmware/iso/config.go
+++ b/builder/vmware/iso/config.go
@@ -24,7 +24,7 @@ import (
 
 // Reference: https://knowledge.broadcom.com/external/article?articleNumber=315655
 const minimumHardwareVersion = 13
-const defaultHardwareVersion = 19
+const defaultHardwareVersion = 21
 
 type Config struct {
 	common.PackerConfig            `mapstructure:",squash"`
@@ -55,7 +55,7 @@ type Config struct {
 	GuestOSType string `mapstructure:"guest_os_type" required:"false"`
 	// The virtual machine hardware version. Refer to [KB 315655](https://knowledge.broadcom.com/external/article?articleNumber=315655)
 	// for more information on supported virtual hardware versions.
-	// Minimum is 13. Default is 19.
+	// Minimum is 13. Default is 21.
 	Version int `mapstructure:"version" required:"false"`
 	// The name of the virtual machine. This represents the name of the virtual
 	// machine `.vmx` configuration file without the file extension.

--- a/docs-partials/builder/vmware/iso/Config-not-required.mdx
+++ b/docs-partials/builder/vmware/iso/Config-not-required.mdx
@@ -12,7 +12,7 @@
 
 - `version` (int) - The virtual machine hardware version. Refer to [KB 315655](https://knowledge.broadcom.com/external/article?articleNumber=315655)
   for more information on supported virtual hardware versions.
-  Minimum is 13. Default is 19.
+  Minimum is 13. Default is 21.
 
 - `vm_name` (string) - The name of the virtual machine. This represents the name of the virtual
   machine `.vmx` configuration file without the file extension.

--- a/example/pkrvars/debian/fusion-12.pkrvars.hcl
+++ b/example/pkrvars/debian/fusion-12.pkrvars.hcl
@@ -5,6 +5,6 @@ iso_url          = "https://cdimage.debian.org/cdimage/archive/11.7.0/amd64/iso-
 iso_checksum     = "cfbb1387d92c83f49420eca06e2d11a23e5a817a21a5d614339749634709a32f"
 data_directory   = "data/debian"
 guest_os_type    = "debian-64"
-hardware_version = 19
+hardware_version = 21
 boot_command     = ["<wait><esc><wait>auto preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg netcfg/get_hostname={{ .Name }}<enter>"]
 vm_name          = "debian_x86_64"

--- a/example/variables.pkr.hcl
+++ b/example/variables.pkr.hcl
@@ -43,7 +43,7 @@ variable "guest_os_type" {
 
 variable "hardware_version" {
   type    = number
-  default = 19 # Refer to VMware versions https://knowledge.broadcom.com/external/article?articleNumber=315655
+  default = 21 # Refer to VMware versions https://knowledge.broadcom.com/external/article?articleNumber=315655
 }
 
 variable "iso_checksum" {


### PR DESCRIPTION
----

### Description
VMware ESXi 7.0 will be out of support in less than 2 months. It sounds logic to update the default hardware version to VMware ESXi 8.0


### Resolved Issues

No opened issue.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

Revert this commit.

### Changes to Security Controls

No changes.

