### PR TITLE
fix: update info message

### DIFF
--- a/builder/vmware/common/driver_workstation.go
+++ b/builder/vmware/common/driver_workstation.go
@@ -304,7 +304,7 @@ func checkNetmapConfExists() (NetworkNameMapper, error) {
 
 	if err == nil {
 		// If the default network mapper configuration file exists, read the configuration.
-		log.Printf("[INFO]Located the network mapper configuration file: %s", pathNetmap)
+		log.Printf("[INFO] Located the network mapper configuration file: %s", pathNetmap)
 		return ReadNetmapConfig(pathNetmap)
 	}
 


### PR DESCRIPTION
### Description

Updates the INFO message when locating the network mapper configuration file to be consistent with all other logged messaged.
