### PR TITLE
chore: move vnc constants

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -81,6 +81,11 @@ const (
 	dhcpVmnetLeasesFile = "vmnetdhcp.leases"
 	natVmnetConfFile    = "vmnetnat.conf"
 	netmapConfFile      = "netmap.conf"
+
+	// VNC settings.
+	defaultVNCPortMin     = 5900
+	defaultVNCPortMax     = 6000
+	defaultVNCBindAddress = "127.0.0.1"
 )
 
 // Versions for supported or required components.

--- a/builder/vmware/common/run_config.go
+++ b/builder/vmware/common/run_config.go
@@ -12,12 +12,6 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 )
 
-const (
-	defaultVNCPortMin     = 5900
-	defaultVNCPortMax     = 6000
-	defaultVNCBindAddress = "127.0.0.1"
-)
-
 type RunConfig struct {
 	// The plugin defaults to building virtual machines by launching the
 	// desktop hypervisor's graphical user interface (GUI) to display the


### PR DESCRIPTION
### Description

Moved the definitions of `defaultVNCPortMin`, `defaultVNCPortMax`, and `defaultVNCBindAddress` from `builder/vmware/common/run_config.go` to `builder/vmware/common/driver.go` to centralize VNC configuration constants. [[1]](diffhunk://#diff-74b31a8d656378719879b7eac5aeae93deed0bead9c50fd413b63e0ab4c51769L15-L20) [[2]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3R84-R88)

### Resolved Issues

This change centralizes configuration for VNC settings in the driver layer, improving code organization and maintainability.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

Revert the commit.

### Changes to Security Controls

None.
