### PR TITLE
chore: move fusion constant

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -27,6 +27,14 @@ const (
 	fusionMinVersion      = "13.5.0"
 	fusionAppPath         = "/Applications/VMware Fusion.app"
 	fusionAppPathVariable = "FUSION_APP_PATH"
+	fusionSuppressPlist   = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>disallowUpgrade</key>
+    <true/>
+</dict>
+</plist>`
 
 	// VMware Workstation.
 	workstationProductName      = "VMware Workstation"

--- a/builder/vmware/common/driver_fusion.go
+++ b/builder/vmware/common/driver_fusion.go
@@ -19,20 +19,10 @@ import (
 
 // VMware Fusion
 
-const fusionSuppressPlist = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>disallowUpgrade</key>
-    <true/>
-</dict>
-</plist>`
-
 // FusionDriver is a driver for VMware Fusion for macOS.
 type FusionDriver struct {
 	VmwareDriver
 
-	// The path to the "VMware Fusion.app"
 	AppPath string
 
 	SSHConfig *SSHConfig


### PR DESCRIPTION
### Description

Moved the definition of the `fusionSuppressPlist` XML constant from `builder/vmware/common/driver_fusion.go` to `builder/vmware/common/driver.go`, consolidating VMware Fusion-related constants in a single file. [[1]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3R28-R35) [[2]](diffhunk://#diff-064807a60c8abca4575708b28ed413bc78aadd53ada1be0dae276089b51fd5feL22-L35)

### Resolved Issues

This change centralizes configuration for Fusion settings in the driver layer, improving code organization and maintainability.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
