### PR TITLE
refactor: remove `ssh_skip_request_pty`

### DIFF
--- a/builder/vmware/common/ssh_config.go
+++ b/builder/vmware/common/ssh_config.go
@@ -6,24 +6,14 @@
 package common
 
 import (
-	"log"
-
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 )
 
 type SSHConfig struct {
 	Comm communicator.Config `mapstructure:",squash"`
-
-	// TODO: Deprecated. Remove in next major release
-	SSHSkipRequestPty bool `mapstructure:"ssh_skip_request_pty"`
 }
 
 func (c *SSHConfig) Prepare(ctx *interpolate.Context) []error {
-	if c.SSHSkipRequestPty {
-		c.Comm.SSHPty = false
-		log.Printf("[WARN] 'ssh_skip_request_pty' is deprecated and will be removed in the next major release.")
-	}
-
 	return c.Comm.Prepare(ctx)
 }

--- a/builder/vmware/iso/config.hcl2spec.go
+++ b/builder/vmware/iso/config.hcl2spec.go
@@ -125,7 +125,6 @@ type FlatConfig struct {
 	WinRMUseSSL                    *bool             `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
 	WinRMInsecure                  *bool             `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
 	WinRMUseNTLM                   *bool             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
-	SSHSkipRequestPty              *bool             `mapstructure:"ssh_skip_request_pty" cty:"ssh_skip_request_pty" hcl:"ssh_skip_request_pty"`
 	ToolsUploadFlavor              *string           `mapstructure:"tools_upload_flavor" required:"false" cty:"tools_upload_flavor" hcl:"tools_upload_flavor"`
 	ToolsUploadPath                *string           `mapstructure:"tools_upload_path" required:"false" cty:"tools_upload_path" hcl:"tools_upload_path"`
 	ToolsSourcePath                *string           `mapstructure:"tools_source_path" required:"false" cty:"tools_source_path" hcl:"tools_source_path"`
@@ -280,7 +279,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_use_ssl":                  &hcldec.AttrSpec{Name: "winrm_use_ssl", Type: cty.Bool, Required: false},
 		"winrm_insecure":                 &hcldec.AttrSpec{Name: "winrm_insecure", Type: cty.Bool, Required: false},
 		"winrm_use_ntlm":                 &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
-		"ssh_skip_request_pty":           &hcldec.AttrSpec{Name: "ssh_skip_request_pty", Type: cty.Bool, Required: false},
 		"tools_upload_flavor":            &hcldec.AttrSpec{Name: "tools_upload_flavor", Type: cty.String, Required: false},
 		"tools_upload_path":              &hcldec.AttrSpec{Name: "tools_upload_path", Type: cty.String, Required: false},
 		"tools_source_path":              &hcldec.AttrSpec{Name: "tools_source_path", Type: cty.String, Required: false},

--- a/builder/vmware/vmx/config.hcl2spec.go
+++ b/builder/vmware/vmx/config.hcl2spec.go
@@ -109,7 +109,6 @@ type FlatConfig struct {
 	WinRMUseSSL               *bool             `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
 	WinRMInsecure             *bool             `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
 	WinRMUseNTLM              *bool             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
-	SSHSkipRequestPty         *bool             `mapstructure:"ssh_skip_request_pty" cty:"ssh_skip_request_pty" hcl:"ssh_skip_request_pty"`
 	ToolsUploadFlavor         *string           `mapstructure:"tools_upload_flavor" required:"false" cty:"tools_upload_flavor" hcl:"tools_upload_flavor"`
 	ToolsUploadPath           *string           `mapstructure:"tools_upload_path" required:"false" cty:"tools_upload_path" hcl:"tools_upload_path"`
 	ToolsSourcePath           *string           `mapstructure:"tools_source_path" required:"false" cty:"tools_source_path" hcl:"tools_source_path"`
@@ -244,7 +243,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_use_ssl":                  &hcldec.AttrSpec{Name: "winrm_use_ssl", Type: cty.Bool, Required: false},
 		"winrm_insecure":                 &hcldec.AttrSpec{Name: "winrm_insecure", Type: cty.Bool, Required: false},
 		"winrm_use_ntlm":                 &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
-		"ssh_skip_request_pty":           &hcldec.AttrSpec{Name: "ssh_skip_request_pty", Type: cty.Bool, Required: false},
 		"tools_upload_flavor":            &hcldec.AttrSpec{Name: "tools_upload_flavor", Type: cty.String, Required: false},
 		"tools_upload_path":              &hcldec.AttrSpec{Name: "tools_upload_path", Type: cty.String, Required: false},
 		"tools_source_path":              &hcldec.AttrSpec{Name: "tools_source_path", Type: cty.String, Required: false},


### PR DESCRIPTION
### Description

This pull request cleans up the `builder/vmware/common/ssh_config.go` file by removing deprecated code and unnecessary imports. The most important changes are focused on deprecating the `ssh_skip_request_pty` option and simplifying the `Prepare` method.

Deprecation and code cleanup:

* Removed the deprecated `SSHSkipRequestPty` field and its related logic from the `SSHConfig` struct and `Prepare` method. This option is no longer supported and the warning log has been eliminated.
* Removed the unused `log` import since logging for deprecation is no longer needed.

### Resolved Issues

Removes deprecated code and unnecessary imports.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

Revert commit.

### Changes to Security Controls

None.

