### PR TITLE
refactor: enforce minimum ovftool version

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -752,9 +752,7 @@ func CheckOvfToolVersion(ovftoolPath string) error {
 	}
 
 	if currentVersion.LessThan(ovfToolMinVersionObj) {
-		log.Printf("[WARN] The version of ovftool (%s) is below the minimum recommended version (%s). Please download the latest version from %s.", currentVersion, ovfToolMinVersionObj, ovfToolDownloadURL)
-		// Log a warning; do not return an error.
-		// TODO: Transition this to an error in a future major release.
+		return fmt.Errorf("ovftool version %s is incompatible; requires version %s or later, download from %s", currentVersion, ovfToolMinVersionObj, ovfToolDownloadURL)
 	}
 
 	return nil


### PR DESCRIPTION
### Description

This pull request updates the version check logic for `ovftool` in the driver. Instead of logging a warning when the installed version is below the minimum required, it now returns an error, enforcing stricter compatibility requirements.

The `CheckOvfToolVersion` function in `builder/vmware/common/driver.go` now returns an error if the detected `ovftool` version is below the minimum required, rather than just logging a warning. This change ensures that builds will fail early if an incompatible version is detected.

### Resolved Issues

Error handling and compatibility enforcement.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

Revert commit.

### Changes to Security Controls

None.

