### PR TITLE
refactor: add hardware default constants

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -115,7 +115,7 @@ JSON Example:
 
 - `cores` (int) - The number of virtual CPU cores per socket for the virtual machine.
 
-- `memory` (int) - The amount of memory for the virtual machine in MB.
+- `memory` (int) - The amount of memory for the virtual machine in MB. Defaults to `512`.
 
 - `network` (string) - The network which the virtual machine will connect for local desktop
   hypervisors. Use the generic values that map to a device, such as

--- a/builder/vmware/common/disk_config.go
+++ b/builder/vmware/common/disk_config.go
@@ -57,11 +57,11 @@ func (c *DiskConfig) Prepare(ctx *interpolate.Context) []error {
 	var errs []error
 
 	if c.DiskName == "" {
-		c.DiskName = "disk"
+		c.DiskName = defaultDiskName
 	}
 
 	if c.DiskAdapterType == "" {
-		c.DiskAdapterType = "lsilogic"
+		c.DiskAdapterType = defaultDiskAdapterType
 	}
 
 	return errs

--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -113,15 +113,34 @@ const (
 	shutdownLockPollInterval = 150 * time.Millisecond
 	shutdownCleanupDelay     = 5 * time.Second
 
-	// Export formats.
+	// ExportFormatOvf defines the export format as "ovf" for Open Virtualization Format.
 	ExportFormatOvf = "ovf"
-	ExportFormatOva = "ova"
+	// exportFormatOva defines the export format as "ova" for Open Virtualization Appliance.
+	exportFormatOva = "ova"
+	// ExportFormatVmx defines the export format as "vmx" for Virtual Machine eXchange.
 	ExportFormatVmx = "vmx"
 
 	// Tools flavors.
 	toolsFlavorMacOS   = osMacOS
 	toolsFlavorLinux   = osLinux
 	toolsFlavorWindows = osWindows
+
+	// DefaultMemorySize specifies the default memory size (in MB) for a virtual machine configuration.
+	DefaultMemorySize = 512
+	// DefaultDiskSize specifies the default size, in megabytes, allocated for a virtual machine's primary disk.
+	DefaultDiskSize = 40000
+	// DefaultDiskType specifies the default disk type for a virtual machine's primary disk.
+	DefaultDiskType = "1" // Growable virtual disk split in 2GB files. Must be a string, not an int.
+	// defaultDiskName specifies the default disk name for a virtual machine's primary disk.
+	defaultDiskName = "disk"
+	// defaultDiskAdapterType specifies the default disk adapter type for a virtual machine's primary disk.'
+	defaultDiskAdapterType = "lsilogic"
+	// DefaultGuestOsType specifies the default guest operating system type for a virtual machine.
+	DefaultGuestOsType = "other"
+	// DefaultNetworkType specifies the default network type for a virtual machine.
+	DefaultNetworkType = "nat"
+	// DefaultNetworkAdapterType specifies the default network adapter type for a virtual machine.
+	DefaultNetworkAdapterType = "e1000"
 )
 
 // Versions for supported or required components.
@@ -134,7 +153,7 @@ var (
 // The allowed export formats for a virtual machine.
 var allowedExportFormats = []string{
 	ExportFormatOvf,
-	ExportFormatOva,
+	exportFormatOva,
 	ExportFormatVmx,
 }
 

--- a/builder/vmware/common/hw_config.go
+++ b/builder/vmware/common/hw_config.go
@@ -24,7 +24,7 @@ type HWConfig struct {
 	CpuCount int `mapstructure:"cpus" required:"false"`
 	// The number of virtual CPU cores per socket for the virtual machine.
 	CoreCount int `mapstructure:"cores" required:"false"`
-	// The amount of memory for the virtual machine in MB.
+	// The amount of memory for the virtual machine in MB. Defaults to `512`.
 	MemorySize int `mapstructure:"memory" required:"false"`
 	// The network which the virtual machine will connect for local desktop
 	// hypervisors. Use the generic values that map to a device, such as

--- a/builder/vmware/iso/config.go
+++ b/builder/vmware/iso/config.go
@@ -129,12 +129,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	errs = packersdk.MultiErrorAppend(errs, c.DiskConfig.Prepare(&c.ctx)...)
 
 	if c.DiskSize == 0 {
-		c.DiskSize = 40000
+		c.DiskSize = vmwcommon.DefaultDiskSize
 	}
 
 	if c.DiskTypeId == "" {
-		// Default is growable virtual disk split in 2GB files.
-		c.DiskTypeId = "1"
+		c.DiskTypeId = vmwcommon.DefaultDiskType
 
 		if c.RemoteType == "esxi" {
 			c.DiskTypeId = "zeroedthick"
@@ -150,7 +149,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	}
 
 	if c.GuestOSType == "" {
-		c.GuestOSType = "other"
+		c.GuestOSType = vmwcommon.DefaultGuestOsType
 	}
 
 	if c.VMName == "" {

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -182,7 +182,7 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 		DiskName:       config.DiskName,
 		Version:        strconv.Itoa(config.Version),
 		ISOPath:        isoPath,
-		NetworkAdapter: "e1000",
+		NetworkAdapter: common.DefaultNetworkAdapterType,
 
 		SoundPresent: map[bool]string{true: "TRUE", false: "FALSE"}[config.Sound],
 		UsbPresent:   map[bool]string{true: "TRUE", false: "FALSE"}[config.USB],
@@ -247,10 +247,9 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 		// if NetworkMapper is nil, then we're using something like ESX, so fall
 		// back to the previous logic of using "nat" despite it not mattering to ESX.
 	} else {
-		templateData.NetworkType = "nat"
+		templateData.NetworkType = common.DefaultNetworkType
 		templateData.NetworkDevice = network
-
-		network = "nat"
+		network = common.DefaultNetworkType
 	}
 
 	// store the network so that we can later figure out what ip address to bind to
@@ -286,16 +285,14 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 			}
 		}
 
-		// Set the number of cpus if it was specified
 		if config.CpuCount > 0 {
 			templateData.CpuCount = strconv.Itoa(config.CpuCount)
 		}
 
-		// Apply the memory size that was specified
 		if config.MemorySize > 0 {
 			templateData.MemorySize = strconv.Itoa(config.MemorySize)
 		} else {
-			templateData.MemorySize = "512"
+			templateData.MemorySize = strconv.Itoa(common.DefaultMemorySize)
 		}
 
 		switch serial.Union.(type) {
@@ -326,7 +323,7 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 		}
 	}
 
-	/// check if parallel port has been configured
+	// Check if parallel port has been configured.
 	if !config.HasParallel() {
 		templateData.ParallelPresent = "FALSE"
 	} else {

--- a/builder/vmware/vmx/config.go
+++ b/builder/vmware/vmx/config.go
@@ -132,8 +132,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	}
 
 	if c.DiskTypeId == "" {
-		// Default is growable virtual disk split in 2GB files.
-		c.DiskTypeId = "1"
+		c.DiskTypeId = vmwcommon.DefaultDiskType
 
 		if c.RemoteType == "esxi" {
 			c.DiskTypeId = "zeroedthick"

--- a/docs-partials/builder/vmware/common/HWConfig-not-required.mdx
+++ b/docs-partials/builder/vmware/common/HWConfig-not-required.mdx
@@ -8,7 +8,7 @@
 
 - `cores` (int) - The number of virtual CPU cores per socket for the virtual machine.
 
-- `memory` (int) - The amount of memory for the virtual machine in MB.
+- `memory` (int) - The amount of memory for the virtual machine in MB. Defaults to `512`.
 
 - `network` (string) - The network which the virtual machine will connect for local desktop
   hypervisors. Use the generic values that map to a device, such as


### PR DESCRIPTION
### Description

Standardizes default values for several virtual machine configuration options and updates documentation to reflect these defaults. The main changes ensure consistency in how defaults are set and referenced in both code and documentation, making it easier for users to understand and rely on sensible defaults when configuring VMs.

**Default value standardization**

* Introduced constants for default values in `builder/vmware/common/driver.go`, including `DefaultMemorySize`, `DefaultDiskSize`, `DefaultGuestOsType`, `DefaultNetworkType`, and `DefaultNetworkAdapterType`. These are now used throughout the codebase for consistency.

* Updated logic in `builder/vmware/iso/config.go` and `builder/vmware/iso/step_create_vmx.go` to use these constants for defaulting disk size, guest OS type, network adapter, network type, and memory size when not explicitly set by the user. [[1]](diffhunk://#diff-6a22861e2ec726ec0cc6112f8892aacd7cc6f3a86c1c53cace1357f215fad35eL132-R132) [[2]](diffhunk://#diff-6a22861e2ec726ec0cc6112f8892aacd7cc6f3a86c1c53cace1357f215fad35eL153-R153) [[3]](diffhunk://#diff-69b312abca15e1a6e28abae7463a3d2ce360e110d54a0b2cf9d37bf3429f7e3aL185-R185) [[4]](diffhunk://#diff-69b312abca15e1a6e28abae7463a3d2ce360e110d54a0b2cf9d37bf3429f7e3aL250-R252) [[5]](diffhunk://#diff-69b312abca15e1a6e28abae7463a3d2ce360e110d54a0b2cf9d37bf3429f7e3aL289-R295)

**Documentation updates**

* Changed documentation in `.web-docs/components/builder/iso/README.md`, `docs-partials/builder/vmware/common/HWConfig-not-required.mdx`, and `docs-partials/builder/vmware/iso/Config-not-required.mdx` to indicate the default values for and `memory` (`512`). [[1]](diffhunk://#diff-65e329d9f6a8d0aecefed129bf5c4d7f389b1b5875468ccd963c6fbade3b50d0L67-R67) [[2]](diffhunk://#diff-65e329d9f6a8d0aecefed129bf5c4d7f389b1b5875468ccd963c6fbade3b50d0L118-R118) [[3]](diffhunk://#diff-385cd576c6630a4d1e75fc453a45cb7db87745eb569e59f5bb5ee452cb1cb104L11-R11) [[4]](diffhunk://#diff-1fbe0b800ea8f24423d09a238773f05fba2807c8ac9865aa2994a6c663f564d6L11-R11)

**Code comments and cleanup**

* Updated comments in `builder/vmware/common/hw_config.go` and `builder/vmware/iso/config.go` to reflect new default values for configuration fields. [[1]](diffhunk://#diff-5abb38f2f9b2a09eef799c250f9db4cd18a48b5a84cb4a4f458e427d4798bdbeL31-R31) [[2]](diffhunk://#diff-6a22861e2ec726ec0cc6112f8892aacd7cc6f3a86c1c53cace1357f215fad35eL54-R54)
* Minor code comment cleanup in `builder/vmware/iso/step_create_vmx.go` for clarity.

### Resolved Issues

None.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
