### PR TITLE
refactor: centralize allowed values and constants

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -107,6 +107,16 @@ const (
 	shutdownLockTimeout      = 120 * time.Second
 	shutdownLockPollInterval = 150 * time.Millisecond
 	shutdownCleanupDelay     = 5 * time.Second
+
+	// Export formats.
+	ExportFormatOvf = "ovf"
+	ExportFormatOva = "ova"
+	ExportFormatVmx = "vmx"
+
+	// Tools flavors.
+	toolsFlavorMacOS   = osMacOS
+	toolsFlavorLinux   = osLinux
+	toolsFlavorWindows = osWindows
 )
 
 // Versions for supported or required components.
@@ -115,6 +125,27 @@ var (
 	workstationMinVersionObj = version.Must(version.NewVersion(workstationMinVersion))
 	ovfToolMinVersionObj     = version.Must(version.NewVersion(ovfToolMinVersion))
 )
+
+// The allowed export formats for a virtual machine.
+var allowedExportFormats = []string{
+	ExportFormatOvf,
+	ExportFormatOva,
+	ExportFormatVmx,
+}
+
+// The allowed firmware types for a virtual machine.
+var allowedFirmwareTypes = []string{
+	FirmwareTypeBios,
+	FirmwareTypeUEFI,
+	FirmwareTypeUEFISecure,
+}
+
+// The allowed values for the `ToolsUploadFlavor`.
+var allowedToolsFlavorValues = []string{
+	toolsFlavorMacOS,
+	toolsFlavorLinux,
+	toolsFlavorWindows,
+}
 
 // The possible paths to the DHCP leases file.
 var dhcpLeasesPaths = []string{
@@ -130,6 +161,15 @@ var dhcpConfPaths = []string{
 	"dhcp/dhcpd.conf",
 	"dhcpd/dhcp.conf",
 	"dhcpd/dhcpd.conf",
+}
+
+// The file extensions to retain when cleaning up files in a virtual machine environment.
+var fileExtensions = []string{
+	".nvram",
+	".vmdk",
+	".vmsd",
+	".vmx",
+	".vmxf",
 }
 
 // The product version.

--- a/builder/vmware/common/export_config.go
+++ b/builder/vmware/common/export_config.go
@@ -13,17 +13,6 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 )
 
-// Set the export formats for the virtual machine.
-const (
-	ExportFormatOvf = "ovf"
-	ExportFormatOva = "ova"
-	ExportFormatVmx = "vmx"
-)
-
-// allowedFormatValues is a list of allowed export formats for the virtual
-// machine.
-var allowedExportFormats = []string{ExportFormatOvf, ExportFormatOva, ExportFormatVmx}
-
 type ExportConfig struct {
 	// The output format of the exported virtual machine. Allowed values are
 	// `ova`, `ovf`, or `vmx`. Defaults to `vmx` for local desktop hypervisors

--- a/builder/vmware/common/hw_config.go
+++ b/builder/vmware/common/hw_config.go
@@ -15,10 +15,6 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 )
 
-// allowedFirmwareTypes is a list of allowed firmware types for the virtual
-// machine.
-var allowedFirmwareTypes = []string{FirmwareTypeBios, FirmwareTypeUEFI, FirmwareTypeUEFISecure}
-
 type HWConfig struct {
 	// The firmware type for the virtual machine.
 	// Allowed values are `bios`, `efi`, and `efi-secure` (for secure boot).

--- a/builder/vmware/common/step_clean_files.go
+++ b/builder/vmware/common/step_clean_files.go
@@ -12,9 +12,6 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 )
 
-// KeepFileExtensions is a list of file extensions to retain when cleaning up files in a virtual machine environment.
-var KeepFileExtensions = []string{".nvram", ".vmdk", ".vmsd", ".vmx", ".vmxf"}
-
 // StepCleanFiles represents a step for cleaning up unnecessary files from a directory.
 type StepCleanFiles struct{}
 
@@ -34,7 +31,7 @@ func (StepCleanFiles) Run(ctx context.Context, state multistep.StateBag) multist
 		// virtual machine, we get rid of it.
 		keep := false
 		ext := filepath.Ext(path)
-		for _, goodExt := range KeepFileExtensions {
+		for _, goodExt := range fileExtensions {
 			if goodExt == ext {
 				keep = true
 				break

--- a/builder/vmware/common/tools_config.go
+++ b/builder/vmware/common/tools_config.go
@@ -14,17 +14,6 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 )
 
-// Set the allowed values for the `ToolsUploadFlavor`.
-const (
-	ToolsFlavorMacOS   = osMacOS
-	ToolsFlavorLinux   = osLinux
-	ToolsFlavorWindows = osWindows
-)
-
-// allowedToolsFlavorValues is a list of allowed values for the
-// `ToolsUploadFlavor`.
-var allowedToolsFlavorValues = []string{ToolsFlavorMacOS, ToolsFlavorLinux, ToolsFlavorWindows}
-
 type ToolsConfig struct {
 	// The flavor of VMware Tools to upload into the virtual machine based on
 	// the guest operating system. Allowed values are `darwin` (macOS), `linux`,

--- a/builder/vmware/iso/config.go
+++ b/builder/vmware/iso/config.go
@@ -181,14 +181,14 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
 	if c.Format == "" {
 		if c.RemoteType == "" {
-			c.Format = "vmx"
+			c.Format = vmwcommon.ExportFormatVmx
 		} else {
-			c.Format = "ovf"
+			c.Format = vmwcommon.ExportFormatOvf
 		}
 	}
 
 	if c.RemoteType == "" {
-		if c.Format == "vmx" {
+		if c.Format == vmwcommon.ExportFormatVmx {
 			// Set skip export flag to avoid an unneeded export.
 			c.SkipExport = true
 		}

--- a/builder/vmware/vmx/config.go
+++ b/builder/vmware/vmx/config.go
@@ -137,13 +137,13 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
 	if c.Format == "" {
 		if c.RemoteType == "" {
-			c.Format = "vmx"
+			c.Format = vmwcommon.ExportFormatVmx
 		} else {
-			c.Format = "ovf"
+			c.Format = vmwcommon.ExportFormatOvf
 		}
 	}
 
-	if c.RemoteType == "" && c.Format == "vmx" {
+	if c.RemoteType == "" && c.Format == vmwcommon.ExportFormatVmx {
 		// if we're building locally and want a vmx, there's nothing to export.
 		// Set skip export flag here to keep the export step from attempting
 		// an unneeded export


### PR DESCRIPTION
### Description

Centralizes the definitions of allowed values and constants for export formats, firmware types, file extensions, and VMware Tools flavors by moving them from individual config files into `builder/vmware/common/driver.go`. This improves maintainability and reduces duplication across the codebase.

* Moved the export format constants (`ovf`, `ova`, `vmx`) and the `allowedExportFormats` list from `export_config.go` to `driver.go`, and removed their previous definitions. [[1]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3R110-R119) [[2]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3R129-R149) [[3]](diffhunk://#diff-7158161d20d6e82e3ff987e7f165940344bb108b246bba667af9dceac9502eb5L16-L26)
* Moved the allowed firmware types (`bios`, `efi`, `efi-secure`) from `hw_config.go` to `driver.go`, removing the old list. [[1]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3R129-R149) [[2]](diffhunk://#diff-5abb38f2f9b2a09eef799c250f9db4cd18a48b5a84cb4a4f458e427d4798bdbeL18-L21)
* Moved the allowed VMware Tools flavor values and their constants from `tools_config.go` to `driver.go`, deleting the previous definitions. [[1]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3R110-R119) [[2]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3R129-R149) [[3]](diffhunk://#diff-a56e066c68de1a33ea721f196764080e0fbcaa0ac8da1b073038314c19388462L17-L27)
* Moved the list of file extensions to retain during cleanup (`.nvram`, `.vmdk`, `.vmsd`, `.vmx`, `.vmxf`) from `step_clean_files.go` to `driver.go`, updating the usage in the cleanup logic. [[1]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3R166-R174) [[2]](diffhunk://#diff-cbfcca534c2beb5e3b9f44acab63946962ff577202aa7da78f669c92d6326976L15-L17) [[3]](diffhunk://#diff-cbfcca534c2beb5e3b9f44acab63946962ff577202aa7da78f669c92d6326976L37-R34)

### Resolved Issues

Improve maintainability and reduces duplication across the codebase.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
