### PR TITLE
refactor: naming prefix constant

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -97,9 +97,14 @@ const (
 	defaultVNCPortMax     = 6000
 	defaultVNCBindAddress = "127.0.0.1"
 
-	// Firmware types.
-	FirmwareTypeBios       = "bios"
-	FirmwareTypeUEFI       = "efi"
+	// DefaultNamePrefix is the default prefix used for naming resources in the system.
+	DefaultNamePrefix = "packer"
+
+	// FirmwareTypeBios represents a constant for the BIOS firmware type identifier..
+	FirmwareTypeBios = "bios"
+	// FirmwareTypeUEFI represents a constant for the UEFI firmware type identifier.
+	FirmwareTypeUEFI = "efi"
+	// FirmwareTypeUEFISecure represents a constant for the UEFI firmware with secure boot type identifier.
 	FirmwareTypeUEFISecure = "efi-secure"
 
 	// Shutdown operation timings.
@@ -164,7 +169,7 @@ var dhcpConfPaths = []string{
 }
 
 // The file extensions to retain when cleaning up files in a virtual machine environment.
-var fileExtensions = []string{
+var skipCleanFileExtensions = []string{
 	".nvram",
 	".vmdk",
 	".vmsd",

--- a/builder/vmware/common/step_clean_files.go
+++ b/builder/vmware/common/step_clean_files.go
@@ -31,7 +31,7 @@ func (StepCleanFiles) Run(ctx context.Context, state multistep.StateBag) multist
 		// virtual machine, we get rid of it.
 		keep := false
 		ext := filepath.Ext(path)
-		for _, goodExt := range fileExtensions {
+		for _, goodExt := range skipCleanFileExtensions {
 			if goodExt == ext {
 				keep = true
 				break

--- a/builder/vmware/iso/config.go
+++ b/builder/vmware/iso/config.go
@@ -154,7 +154,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	}
 
 	if c.VMName == "" {
-		c.VMName = fmt.Sprintf("packer-%s", c.PackerBuildName)
+		c.VMName = fmt.Sprintf("%s-%s", vmwcommon.DefaultNamePrefix, c.PackerBuildName)
 	}
 
 	if c.Version == 0 {

--- a/builder/vmware/vmx/config.go
+++ b/builder/vmware/vmx/config.go
@@ -90,6 +90,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 			"packer-%s-%d", c.PackerBuildName, interpolate.InitTime.Unix())
 	}
 
+	if c.VMName == "" {
+		c.VMName = fmt.Sprintf(
+			"%s-%s-%d", vmwcommon.DefaultNamePrefix, c.PackerBuildName, interpolate.InitTime.Unix())
+	}
+
 	// Accumulate any errors and warnings
 	var warnings []string
 	var errs *packersdk.MultiError


### PR DESCRIPTION

### Description

This pull request introduces improvements to naming conventions and file cleanup logic in the codebase. The most notable changes include the introduction of a centralized default resource name prefix, updates to virtual machine naming logic to use this prefix, and a refactor of file extension handling for cleanup operations.

**Naming convention improvements:**

* Added `DefaultNamePrefix` constant (`"packer"`) to `builder/vmware/common/driver.go` for consistent resource naming across the system.
* Updated VM name generation in `builder/vmware/iso/config.go` and `builder/vmware/vmx/config.go` to use the new `DefaultNamePrefix` instead of hardcoded `"packer"` strings, ensuring consistency in VM naming. [[1]](diffhunk://#diff-6a22861e2ec726ec0cc6112f8892aacd7cc6f3a86c1c53cace1357f215fad35eL157-R157) [[2]](diffhunk://#diff-9c61873131cebf1fe29f6a7e987718b0592b83f5cf197da4b7f2ca911ad31c51R93-R97)

**File cleanup logic refactor:**

* Renamed the `fileExtensions` variable to `skipCleanFileExtensions` in `builder/vmware/common/driver.go` for clarity, indicating these are extensions to retain during cleanup.
* Updated usage in `builder/vmware/common/step_clean_files.go` to reference `skipCleanFileExtensions` instead of the old variable name, improving code readability.

**Constants documentation:**

* Improved documentation for firmware type constants in `builder/vmware/common/driver.go`, clarifying their purpose and usage.

### Resolved Issues

None.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

Revert commit.

### Changes to Security Controls

None.

