### PR TITLE
refactor: os checks

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -283,13 +283,13 @@ func NewDriver(dconfig *DriverConfig, config *SSHConfig, vmName string) (Driver,
 
 	} else {
 		switch runtime.GOOS {
-		case "darwin":
+		case osMacOS:
 			drivers = []Driver{
 				NewFusionDriver(dconfig, config),
 			}
-		case "linux":
+		case osLinux:
 			fallthrough
-		case "windows":
+		case osWindows:
 			drivers = []Driver{
 				NewWorkstationDriver(config),
 			}
@@ -589,7 +589,7 @@ func (d *VmwareDriver) PotentialGuestIP(state multistep.StateBag) ([]string, err
 		return addrs, nil
 	}
 
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == osMacOS {
 		// We have match no vmware DHCP lease for this MAC. We'll try to match it in Apple DHCP leases.
 		// As a remember, VMware is no longer able to rely on its own dhcpd server on MacOS BigSur and is
 		// forced to use Apple DHCPD server instead.

--- a/builder/vmware/common/driver_workstation.go
+++ b/builder/vmware/common/driver_workstation.go
@@ -261,7 +261,7 @@ func (d *WorkstationDriver) Verify() error {
 
 		// For non-Windows, if neither the default nor alternate configuration
 		// paths exist, return an error.
-		if err != nil && runtime.GOOS != "windows" {
+		if err != nil && runtime.GOOS != osWindows {
 			return nil, err
 		}
 

--- a/builder/vmware/common/driver_workstation_unix.go
+++ b/builder/vmware/common/driver_workstation_unix.go
@@ -139,7 +139,7 @@ func workstationNetmapConfPath() string {
 // workstationVerifyVersion verifies the VMware Workstation version against the
 // required version using workstationTestVersion.
 func workstationVerifyVersion(version string) error {
-	if runtime.GOOS != "linux" {
+	if runtime.GOOS != osLinux {
 		return fmt.Errorf("driver is only supported on Linux, not %s", runtime.GOOS)
 	}
 

--- a/builder/vmware/common/hw_config.go
+++ b/builder/vmware/common/hw_config.go
@@ -269,7 +269,7 @@ func (c *HWConfig) HasSerial() bool {
 
 func (c *HWConfig) ReadSerial() (*SerialUnion, error) {
 	var defaultSerialPort string
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		defaultSerialPort = "COM1"
 	} else {
 		defaultSerialPort = "/dev/ttyS0"

--- a/builder/vmware/common/tools_config_test.go
+++ b/builder/vmware/common/tools_config_test.go
@@ -57,7 +57,7 @@ func TestToolsConfigPrepare_SourceSuccess(t *testing.T) {
 		},
 		{
 			ToolsSourcePath:   "path/to/tools.iso",
-			ToolsUploadFlavor: "linux",
+			ToolsUploadFlavor: osLinux,
 		},
 	} {
 		errs := c.Prepare(interpolate.NewContext())


### PR DESCRIPTION
### Description

This pull request refactors platform-specific code by replacing string literals representing operating systems with existing predefined constants in the package that were used for VMware Tools. This change improves code maintainability, reduces the risk of typos, and centralizes OS references for easier updates.

**Platform detection refactoring:**

* Replaced string literals such as `"darwin"`, `"linux"`, and `"windows"` with constants (`osMacOS`, `osLinux`, `osWindows`) in the driver selection logic in `driver.go`, improving clarity and maintainability.
* Updated platform checks in guest IP detection and verification routines in `driver.go` to use the new OS constants. [[1]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L592-R592) [[2]](diffhunk://#diff-e97f946704c6b9b64f7f59b64f73fdd359740f700a633ae995a316c3a182f500L264-R264)

**Consistency in hardware and configuration logic:**

* Changed OS string checks to constants in hardware configuration (`hw_config.go`) and workstation version verification (`driver_workstation_unix.go`). [[1]](diffhunk://#diff-5abb38f2f9b2a09eef799c250f9db4cd18a48b5a84cb4a4f458e427d4798bdbeL272-R272) [[2]](diffhunk://#diff-bbe4c1aa0333c30034450736a5adde34d68a010bf8e9d7569e684730124207acL142-R142)

**Test improvements:**

* Updated test configuration to use the new OS constant for the upload flavor in `tools_config_test.go`.

### Resolved Issues

Improved maintainability and consistency.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.

