### PR TITLE
refactor: update artifact builder ids

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -8,8 +8,8 @@ for those who want to start by creating an image for use with VMware [desktop hy
 
 | Hypervisor Type     | Artifact BuilderId     |
 |---------------------|------------------------|
-| Desktop Hypervisor  | `mitchellh.vmware`     |
-| Remote Hypervisor   | `mitchellh.vmware-esx` |
+| Desktop Hypervisor  | `vmware.desktop`     |
+| Remote Hypervisor   | `vmware.esx` |
 
 ## Basic Example
 

--- a/.web-docs/components/builder/vmx/README.md
+++ b/.web-docs/components/builder/vmx/README.md
@@ -9,8 +9,8 @@ back into Packer to iterate on an image for use with VMware [desktop hypervisors
 
 | Hypervisor Type     | Artifact BuilderId     |
 |---------------------|------------------------|
-| Desktop Hypervisor  | `mitchellh.vmware`     |
-| Remote Hypervisor   | `mitchellh.vmware-esx` |
+| Desktop Hypervisor  | `vmware.desktop`     |
+| Remote Hypervisor   | `vmware.esx` |
 
 ## Basic Example
 

--- a/builder/vmware/common/artifact.go
+++ b/builder/vmware/common/artifact.go
@@ -12,10 +12,8 @@ import (
 )
 
 const (
-	// BuilderId for the local artifacts
-	BuilderId    = "mitchellh.vmware"
-	BuilderIdESX = "mitchellh.vmware-esx"
-
+	BuilderId                  = "vmware.desktop"
+	BuilderIdESX               = "vmware.esx"
 	ArtifactConfFormat         = "artifact.conf.format"
 	ArtifactConfKeepRegistered = "artifact.conf.keep_registered"
 	ArtifactConfSkipExport     = "artifact.conf.skip_export"

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -21,8 +21,8 @@ for those who want to start by creating an image for use with VMware [desktop hy
 
 | Hypervisor Type     | Artifact BuilderId     |
 |---------------------|------------------------|
-| Desktop Hypervisor  | `mitchellh.vmware`     |
-| Remote Hypervisor   | `mitchellh.vmware-esx` |
+| Desktop Hypervisor  | `vmware.desktop`     |
+| Remote Hypervisor   | `vmware.esx` |
 
 ## Basic Example
 

--- a/docs/builders/vmx.mdx
+++ b/docs/builders/vmx.mdx
@@ -23,8 +23,8 @@ back into Packer to iterate on an image for use with VMware [desktop hypervisors
 
 | Hypervisor Type     | Artifact BuilderId     |
 |---------------------|------------------------|
-| Desktop Hypervisor  | `mitchellh.vmware`     |
-| Remote Hypervisor   | `mitchellh.vmware-esx` |
+| Desktop Hypervisor  | `vmware.desktop`     |
+| Remote Hypervisor   | `vmware.esx` |
 
 ## Basic Example
 


### PR DESCRIPTION
### Description

Updates the naming conventions for builder IDs throughout the codebase and documentation to use more descriptive and standardized identifiers.

* Updated the builder IDs in `builder/vmware/common/artifact.go` from `mitchellh.vmware` to `vmware.desktop` and from `mitchellh.vmware-esx` to `vmware.esx` for local and ESX artifacts, respectively.
* Changed the builder IDs in `.web-docs/components/builder/iso/README.md` and `.web-docs/components/builder/vmx/README.md` to reflect the new naming convention (`vmware.desktop` and `vmware.esx`). [[1]](diffhunk://#diff-65e329d9f6a8d0aecefed129bf5c4d7f389b1b5875468ccd963c6fbade3b50d0L11-R12) [[2]](diffhunk://#diff-c58a773b5c554ff4d42933e2353ee6f8d08bed77c4c1ae927ae35f248629fd0fL12-R13)
* Updated builder ID references in `docs/builders/iso.mdx` and `docs/builders/vmx.mdx` to use the new standardized names. [[1]](diffhunk://#diff-336394565e07e5edcc2ee153ad8a9191242dc7c0b972570101ffa0351c2e72c9L24-R25) [[2]](diffhunk://#diff-86c1790d4401c3099cac98d923be5e772cb26efa616ebd15ef43eff1c83edcfdL26-R27)

### Resolved Issues

The changes ensure consistency and clarity for users working with the hypervisors.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.

