### PR TITLE
docs: fix markdown formatting

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -228,14 +228,14 @@ JSON Example:
   
     For local desktop hypervisors, the available options are:
   
-    Type ID | Description
-    ------- | ---
-    `0`     | Growable virtual disk contained in a single file (monolithic sparse).
-    `1`     | Growable virtual disk split into 2GB files (split sparse).
-    `2`     | Preallocated virtual disk contained in a single file (monolithic flat).
-    `3`     | Preallocated virtual disk split into 2GB files (split flat).
-    `4`     | Preallocated virtual disk compatible with ESXi (VMFS flat).
-    `5`     | Compressed disk optimized for streaming.
+    | Type ID | Description                                                             |
+    |---------|-------------------------------------------------------------------------|
+    | `0`     | Growable virtual disk contained in a single file (monolithic sparse).   |
+    | `1`     | Growable virtual disk split into 2GB files (split sparse).              |
+    | `2`     | Preallocated virtual disk contained in a single file (monolithic flat). |
+    | `3`     | Preallocated virtual disk split into 2GB files (split flat).            |
+    | `4`     | Preallocated virtual disk compatible with ESXi (VMFS flat).             |
+    | `5`     | Compressed disk optimized for streaming.                                |
   
     Defaults to `1`.
   

--- a/.web-docs/components/builder/vmx/README.md
+++ b/.web-docs/components/builder/vmx/README.md
@@ -117,14 +117,14 @@ JSON Example:
   
     For local desktop hypervisors, the available options are:
   
-    Type ID | Description
-    ------- | ---
-    `0`     | Growable virtual disk contained in a single file (monolithic sparse).
-    `1`     | Growable virtual disk split into 2GB files (split sparse).
-    `2`     | Preallocated virtual disk contained in a single file (monolithic flat).
-    `3`     | Preallocated virtual disk split into 2GB files (split flat).
-    `4`     | Preallocated virtual disk compatible with ESXi (VMFS flat).
-    `5`     | Compressed disk optimized for streaming.
+    | Type ID | Description                                                             |
+    |---------|-------------------------------------------------------------------------|
+    | `0`     | Growable virtual disk contained in a single file (monolithic sparse).   |
+    | `1`     | Growable virtual disk split into 2GB files (split sparse).              |
+    | `2`     | Preallocated virtual disk contained in a single file (monolithic flat). |
+    | `3`     | Preallocated virtual disk split into 2GB files (split flat).            |
+    | `4`     | Preallocated virtual disk compatible with ESXi (VMFS flat).             |
+    | `5`     | Compressed disk optimized for streaming.                                |
   
     Defaults to `1`.
   

--- a/builder/vmware/common/disk_config.go
+++ b/builder/vmware/common/disk_config.go
@@ -29,14 +29,14 @@ type DiskConfig struct {
 	//
 	//   For local desktop hypervisors, the available options are:
 	//
-	//   Type ID | Description
-	//   ------- | ---
-	//   `0`     | Growable virtual disk contained in a single file (monolithic sparse).
-	//   `1`     | Growable virtual disk split into 2GB files (split sparse).
-	//   `2`     | Preallocated virtual disk contained in a single file (monolithic flat).
-	//   `3`     | Preallocated virtual disk split into 2GB files (split flat).
-	//   `4`     | Preallocated virtual disk compatible with ESXi (VMFS flat).
-	//   `5`     | Compressed disk optimized for streaming.
+	//   | Type ID | Description                                                             |
+	//   |---------|-------------------------------------------------------------------------|
+	//   | `0`     | Growable virtual disk contained in a single file (monolithic sparse).   |
+	//   | `1`     | Growable virtual disk split into 2GB files (split sparse).              |
+	//   | `2`     | Preallocated virtual disk contained in a single file (monolithic flat). |
+	//   | `3`     | Preallocated virtual disk split into 2GB files (split flat).            |
+	//   | `4`     | Preallocated virtual disk compatible with ESXi (VMFS flat).             |
+	//   | `5`     | Compressed disk optimized for streaming.                                |
 	//
 	//   Defaults to `1`.
 	//

--- a/docs-partials/builder/vmware/common/DiskConfig-not-required.mdx
+++ b/docs-partials/builder/vmware/common/DiskConfig-not-required.mdx
@@ -19,14 +19,14 @@
   
     For local desktop hypervisors, the available options are:
   
-    Type ID | Description
-    ------- | ---
-    `0`     | Growable virtual disk contained in a single file (monolithic sparse).
-    `1`     | Growable virtual disk split into 2GB files (split sparse).
-    `2`     | Preallocated virtual disk contained in a single file (monolithic flat).
-    `3`     | Preallocated virtual disk split into 2GB files (split flat).
-    `4`     | Preallocated virtual disk compatible with ESXi (VMFS flat).
-    `5`     | Compressed disk optimized for streaming.
+    | Type ID | Description                                                             |
+    |---------|-------------------------------------------------------------------------|
+    | `0`     | Growable virtual disk contained in a single file (monolithic sparse).   |
+    | `1`     | Growable virtual disk split into 2GB files (split sparse).              |
+    | `2`     | Preallocated virtual disk contained in a single file (monolithic flat). |
+    | `3`     | Preallocated virtual disk split into 2GB files (split flat).            |
+    | `4`     | Preallocated virtual disk compatible with ESXi (VMFS flat).             |
+    | `5`     | Compressed disk optimized for streaming.                                |
   
     Defaults to `1`.
   


### PR DESCRIPTION
### Description

Updates documentation and inline code comments to improve the formatting of the table describing disk type options. The main change is converting the disk type table to a markdown format with proper column alignment, making it easier to read and more consistent across the codebase and documentation.

### Resolved Issues

Resolved Markdown linting errors.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
