### PR TITLE
refactor: Improve file handling and logging

### DIFF
--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -144,23 +144,13 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 
 			diskTemplate := DefaultAdditionalDiskTemplate
 			if config.VMXDiskTemplatePath != "" {
-				f, err := os.Open(config.VMXDiskTemplatePath)
+				rawBytes, err := os.ReadFile(config.VMXDiskTemplatePath)
 				if err != nil {
 					err := fmt.Errorf("error reading VMX disk template: %s", err)
 					state.Put("error", err)
 					ui.Error(err.Error())
 					return multistep.ActionHalt
 				}
-				defer f.Close()
-
-				rawBytes, err := io.ReadAll(f)
-				if err != nil {
-					err := fmt.Errorf("error reading VMX disk template: %s", err)
-					state.Put("error", err)
-					ui.Error(err.Error())
-					return multistep.ActionHalt
-				}
-
 				diskTemplate = string(rawBytes)
 			}
 


### PR DESCRIPTION
### Description

Improves resource management and log clarity in the codebase. The main changes include more robust file handling (especially with closing files after reading), better logging practices with explicit log levels, and a simplification in reading disk template files.

* Ensured that file handles for DHCP lease files are explicitly closed after reading, with warnings logged if closing fails, both for standard and Apple DHCP leases in `driver.go`. [[1]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L522-R531) [[2]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L604-R614)
* Updated log messages to include explicit log levels such as `[WARN]` and `[INFO]` for better clarity and consistency throughout DHCP lease handling logic in `driver.go`. [[1]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L522-R531) [[2]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L563-R566) [[3]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L604-R614)
* Replaced manual file opening and reading with a single call to `os.ReadFile` for reading the VMX disk template in `step_create_vmx.go`, simplifying the code and reducing the risk of resource leaks.
* Removed unnecessary defer statements for file closing where file reading is now handled in one step. [[1]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L522-R531) [[2]](diffhunk://#diff-69b312abca15e1a6e28abae7463a3d2ce360e110d54a0b2cf9d37bf3429f7e3aL147-L163)

### Resolved Issues

1. Replaces deferred file closing in loops with immediate close and adds error logging for file close failures in DHCP lease handling. 
2. Updates log levels for consistency and switches to os.ReadFile for reading VMX disk templates, simplifying file reading and error handling.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
