### PR TITLE
refctor: move hardware version constants

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -125,6 +125,10 @@ const (
 	toolsFlavorLinux   = osLinux
 	toolsFlavorWindows = osWindows
 
+	// MinimumHardwareVersion specifies the minimum supported hardware version required for compatibility.
+	MinimumHardwareVersion = 13
+	// DefaultHardwareVersion specifies the default virtual hardware version used during virtual machine creation.
+	DefaultHardwareVersion = 19
 	// DefaultMemorySize specifies the default memory size (in MB) for a virtual machine configuration.
 	DefaultMemorySize = 512
 	// DefaultDiskSize specifies the default size, in megabytes, allocated for a virtual machine's primary disk.

--- a/builder/vmware/iso/builder_test.go
+++ b/builder/vmware/iso/builder_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/packer-plugin-sdk/common"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+	vmwcommon "github.com/hashicorp/packer-plugin-vmware/builder/vmware/common"
 )
 
 func testConfig() map[string]interface{} {
@@ -49,8 +50,8 @@ func TestBuilderPrepare_Defaults(t *testing.T) {
 		t.Errorf("bad output dir: %s", b.config.OutputDir)
 	}
 
-	if b.config.Version < minimumHardwareVersion {
-		t.Errorf("bad version: %d, minimum hardware version: %d", b.config.Version, minimumHardwareVersion)
+	if b.config.Version < vmwcommon.MinimumHardwareVersion {
+		t.Errorf("bad version: %d, minimum hardware version: %d", b.config.Version, vmwcommon.MinimumHardwareVersion)
 	}
 
 	if b.config.VMName != "packer-foo" {

--- a/builder/vmware/iso/config.go
+++ b/builder/vmware/iso/config.go
@@ -22,10 +22,6 @@ import (
 	vmwcommon "github.com/hashicorp/packer-plugin-vmware/builder/vmware/common"
 )
 
-// Reference: https://knowledge.broadcom.com/external/article?articleNumber=315655
-const minimumHardwareVersion = 13
-const defaultHardwareVersion = 19
-
 type Config struct {
 	common.PackerConfig            `mapstructure:",squash"`
 	commonsteps.HTTPConfig         `mapstructure:",squash"`
@@ -157,9 +153,9 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	}
 
 	if c.Version == 0 {
-		c.Version = defaultHardwareVersion
-	} else if c.Version < minimumHardwareVersion {
-		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("invalid 'version' %d, minimum hardware version: %d", c.Version, minimumHardwareVersion))
+		c.Version = vmwcommon.DefaultHardwareVersion
+	} else if c.Version < vmwcommon.MinimumHardwareVersion {
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("invalid 'version' %d, minimum hardware version: %d", c.Version, vmwcommon.MinimumHardwareVersion))
 	}
 
 	if c.VMXTemplatePath != "" {


### PR DESCRIPTION
### Description

Refactors how hardware version constants are managed for virtual machine creation, improving maintainability and consistency across the codebase. The minimum and default hardware version constants are moved to a shared location, and all references are updated accordingly.

* Added `MinimumHardwareVersion` and `DefaultHardwareVersion` constants to `builder/vmware/common/driver.go`, centralizing their definition for use across the project.
* Removed locally defined `minimumHardwareVersion` and `defaultHardwareVersion` constants from `builder/vmware/iso/config.go`, updating the code to use the shared constants from `vmwcommon`.
* Updated the logic in `builder/vmware/iso/config.go` to use `vmwcommon.DefaultHardwareVersion` and `vmwcommon.MinimumHardwareVersion` when preparing configuration, ensuring consistent hardware version checks.
* Modified the test in `builder/vmware/iso/builder_test.go` to reference `vmwcommon.MinimumHardwareVersion` for hardware version validation, ensuring tests align with the new constant location.
* Added import of `vmwcommon` in `builder/vmware/iso/builder_test.go` for access to shared constants.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
