### PR TITLE
refactor: move artifact config constants

### DIFF
--- a/builder/vmware/common/artifact.go
+++ b/builder/vmware/common/artifact.go
@@ -11,14 +11,6 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 )
 
-const (
-	BuilderId                  = "vmware.desktop"
-	BuilderIdESX               = "vmware.esx"
-	ArtifactConfFormat         = "artifact.conf.format"
-	ArtifactConfKeepRegistered = "artifact.conf.keep_registered"
-	ArtifactConfSkipExport     = "artifact.conf.skip_export"
-)
-
 // Artifact is the result of running the VMware builder, namely a set
 // of files associated with the resulting machine.
 type artifact struct {
@@ -79,15 +71,15 @@ func NewArtifact(remoteType string, format string, exportOutputPath string, vmNa
 	}
 
 	// Set the proper builder ID
-	builderId := BuilderId
+	builderId := builderId
 	if remoteType != "" {
-		builderId = BuilderIdESX
+		builderId = builderIdESX
 	}
 
 	config := make(map[string]string)
-	config[ArtifactConfKeepRegistered] = strconv.FormatBool(keepRegistered)
-	config[ArtifactConfFormat] = format
-	config[ArtifactConfSkipExport] = strconv.FormatBool(skipExport)
+	config[artifactConfKeepRegistered] = strconv.FormatBool(keepRegistered)
+	config[artifactConfFormat] = format
+	config[artifactConfSkipExport] = strconv.FormatBool(skipExport)
 
 	return &artifact{
 		builderId: builderId,

--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -22,6 +22,15 @@ import (
 )
 
 const (
+	// Builder ID.
+	builderId    = "vmware.desktop"
+	builderIdESX = "vmware.esx"
+
+	// Artifact configuration keys.
+	artifactConfFormat         = "artifact.conf.format"
+	artifactConfKeepRegistered = "artifact.conf.keep_registered"
+	artifactConfSkipExport     = "artifact.conf.skip_export"
+
 	// VMware Fusion.
 	fusionProductName     = "VMware Fusion"
 	fusionMinVersion      = "13.5.0"


### PR DESCRIPTION
## Description

Refactors the way builder IDs and artifact configuration keys are defined and used in the builder code. The main change is moving these constants from `artifact.go` to `driver.go`, updating their names to follow Go naming conventions, and updating their usage accordingly.

* Moved builder ID and artifact configuration key constants from `builder/vmware/common/artifact.go` to `builder/vmware/common/driver.go`, and renamed them to use lowerCamelCase for improved code style and clarity. [[1]](diffhunk://#diff-177a2e20c1bc5c97b70479adbe9a590f0fe297eb0a64c2c8f51e72c0e3e705b0L14-L21) [[2]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3R25-R33)
* Updated references to these constants throughout `artifact.go` to use the new names, ensuring consistency and avoiding compilation errors.

### Resolved Issues

Relocated builderId and artifact configuration key constants for better organization and encapsulation.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.