### PR TITLE
chore: standardize log messages

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -306,12 +306,12 @@ func NewDriver(dconfig *DriverConfig, config *SSHConfig, vmName string) (Driver,
 	for _, driver := range drivers {
 		err := driver.Verify()
 
-		log.Printf("Using driver %T, Success: %t", driver, err == nil)
+		log.Printf("[INFO] Using driver %T, Success: %t", driver, err == nil)
 		if err == nil {
 			return driver, nil
 		}
 
-		log.Printf("Skipping %T because it failed with the following error %s", driver, err)
+		log.Printf("[INFO] Skipping %T because it failed with the following error %s", driver, err)
 		errs += "* " + err.Error() + "\n"
 	}
 
@@ -456,7 +456,7 @@ func (d *VmwareDriver) GuestAddress(state multistep.StateBag) (string, error) {
 			return "", errors.New("unable to determine MAC address")
 		}
 	}
-	log.Printf("[INFO] GuestAddress discovered MAC address: %s", macAddress)
+	log.Printf("[INFO] Discovered MAC address: %s", macAddress)
 
 	res, err := net.ParseMAC(macAddress)
 	if err != nil {
@@ -480,7 +480,7 @@ func (d *VmwareDriver) PotentialGuestIP(state multistep.StateBag) ([]string, err
 
 	// log them to see what was detected
 	for _, device := range devices {
-		log.Printf("[INFO] GuestIP discovered device matching %s: %s", network, device)
+		log.Printf("[INFO] Discovered device matching %s: %s", network, device)
 	}
 
 	// we were unable to find the device, maybe it's a custom one...
@@ -498,7 +498,7 @@ func (d *VmwareDriver) PotentialGuestIP(state multistep.StateBag) ([]string, err
 		if err != nil {
 			return []string{}, err
 		}
-		log.Printf("[INFO] GuestIP discovered custom device matching %s: %s", network, device)
+		log.Printf("[INFO] Discovered custom device matching %s: %s", network, device)
 	}
 
 	// figure out our MAC address for looking up the guest address
@@ -521,7 +521,7 @@ func (d *VmwareDriver) PotentialGuestIP(state multistep.StateBag) ([]string, err
 		// open up the path to the dhcpd leases
 		fh, err := os.Open(dhcpLeasesPath)
 		if err != nil {
-			log.Printf("[WARN] Error reading DHCP lease path file %s: %s", dhcpLeasesPath, err.Error())
+			log.Printf("[WARN] Failed to read DHCP lease path file %s: %s", dhcpLeasesPath, err.Error())
 			continue
 		}
 
@@ -566,7 +566,7 @@ func (d *VmwareDriver) PotentialGuestIP(state multistep.StateBag) ([]string, err
 		// If we weren't able to grab any results, then we'll do a "loose"-match
 		// where we only look for anything where the hardware address matches.
 		if len(results) == 0 {
-			log.Printf("[INFO] Unable to find an exact match for DHCP lease. Falling back loose matching for a hardware address %v", MACAddress)
+			log.Printf("[INFO] Failed to find an exact match for DHCP lease. Falling back loose matching for a hardware address %v", MACAddress)
 			for _, entry := range leaseEntries {
 				if bytes.Equal(hwaddr, entry.ether) {
 					results = append(results, entry)
@@ -607,7 +607,7 @@ func (d *VmwareDriver) PotentialGuestIP(state multistep.StateBag) ([]string, err
 		// open up the path to the apple dhcpd leases
 		fh, err := os.Open(appleDhcpLeasesPath)
 		if err != nil {
-			log.Printf("[WARN] Error while reading Apple DHCP leases path file %s: %s", appleDhcpLeasesPath, err.Error())
+			log.Printf("[WARN] Failed to read Apple DHCP leases path file %s: %s", appleDhcpLeasesPath, err.Error())
 		} else {
 			defer func(fh *os.File) {
 				err := fh.Close()
@@ -667,7 +667,7 @@ func (d *VmwareDriver) HostAddress(state multistep.StateBag) (string, error) {
 
 	// log them to see what was detected
 	for _, device := range devices {
-		log.Printf("[INFO] HostAddress discovered device matching %s: %s", network, device)
+		log.Printf("[INFO] Discovered device matching %s: %s", network, device)
 	}
 
 	// we were unable to find the device, maybe it's a custom one...
@@ -685,7 +685,7 @@ func (d *VmwareDriver) HostAddress(state multistep.StateBag) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		log.Printf("[INFO] HostAddress discovered custom device matching %s: %s", network, device)
+		log.Printf("[INFO] Discovered custom device matching %s: %s", network, device)
 	}
 
 	var lastError error
@@ -748,7 +748,7 @@ func (d *VmwareDriver) HostIP(state multistep.StateBag) (string, error) {
 
 	// log them to see what was detected
 	for _, device := range devices {
-		log.Printf("[INFO] HostIP discovered device matching %s: %s", network, device)
+		log.Printf("[INFO] Discovered device matching %s: %s", network, device)
 	}
 
 	// we were unable to find the device, maybe it's a custom one...
@@ -766,7 +766,7 @@ func (d *VmwareDriver) HostIP(state multistep.StateBag) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		log.Printf("[INFO] HostIP discovered custom device matching %s: %s", network, device)
+		log.Printf("[INFO] Discovered custom device matching %s: %s", network, device)
 	}
 
 	var lastError error
@@ -827,7 +827,7 @@ func GetOvfTool() string {
 func CheckOvfToolVersion(ovftoolPath string) error {
 	output, err := exec.Command(ovftoolPath, "--version").CombinedOutput()
 	if err != nil {
-		log.Printf("[WARN] Error running 'ovftool --version': %v.", err)
+		log.Printf("[WARN] Failed to run 'ovftool --version': %v.", err)
 		log.Printf("[WARN] Returned: %s", string(output))
 		return errors.New("failed to execute ovftool")
 	}

--- a/builder/vmware/common/driver_esxi.go
+++ b/builder/vmware/common/driver_esxi.go
@@ -124,8 +124,8 @@ func (d *EsxiDriver) Clone(dst, src string, linked bool, snapshot string) error 
 	srcDir := path.Dir(srcVmx)
 	dstDir := path.Dir(dstVmx)
 
-	log.Printf("Source: %s\n", srcVmx)
-	log.Printf("Destination: %s\n", dstVmx)
+	log.Printf("[INFO] Source: %s\n", srcVmx)
+	log.Printf("[INFO] Destination: %s\n", dstVmx)
 
 	err := d.MkdirAll()
 	if err != nil {
@@ -168,7 +168,7 @@ func (d *EsxiDriver) Clone(dst, src string, linked bool, snapshot string) error 
 			return fmt.Errorf("error cloning disk %s: %s", srcDisk, err)
 		}
 	}
-	log.Printf("Successfully cloned %s to %s\n", src, dst)
+	log.Printf("[INFO] Successfully cloned %s to %s\n", src, dst)
 	return nil
 }
 
@@ -263,12 +263,12 @@ func (d *EsxiDriver) UploadISO(localPath string, checksum string, ui packersdk.U
 		return "", err
 	}
 
-	log.Printf("Verifying checksum of %s", finalPath)
+	log.Printf("[INFO] Verifying checksum of %s", finalPath)
 	if d.VerifyChecksum(checksum, finalPath) {
-		log.Println("Checksum matched. Skipping upload.")
+		log.Println("[INFO] Checksum matched. Skipping upload.")
 		return finalPath, nil
 	}
-	log.Println("Checksum did not match. Uploading...")
+	log.Println("[INFO] Checksum did not match. Uploading...")
 
 	if err := d.upload(finalPath, localPath, ui); err != nil {
 		return "", err
@@ -285,7 +285,7 @@ func (d *EsxiDriver) UploadISO(localPath string, checksum string, ui packersdk.U
 
 func (d *EsxiDriver) RemoveCache(localPath string) error {
 	finalPath := d.CachePath(localPath)
-	log.Printf("Removing remote cache path %s (local %s)...", finalPath, localPath)
+	log.Printf("[INFO] Removing remote cache path %s (local %s)...", finalPath, localPath)
 	return d.sh("rm", "-f", strconv.Quote(finalPath))
 }
 
@@ -352,7 +352,7 @@ func (d *EsxiDriver) VerifyOvfTool(SkipExport, skipValidateCredentials bool) err
 		return nil
 	}
 
-	log.Printf("Verifying credentials for ovftool...")
+	log.Printf("[INFO] Verifying credentials for ovftool...")
 	ovftool := GetOvfTool()
 
 	if d.Password == "" {

--- a/builder/vmware/common/driver_parser_test.go
+++ b/builder/vmware/common/driver_parser_test.go
@@ -349,13 +349,13 @@ parameters : map[default-lease-time:1800 max-lease-time:7200]
 
 	f, err := os.Open(filepath.Join("testdata", "dhcpd-example.conf"))
 	if err != nil {
-		t.Fatalf("Unable to open dhcpd.conf sample: %s", err)
+		t.Fatalf("Failed to open dhcpd.conf sample: %s", err)
 	}
 	defer f.Close()
 
 	config, err := ReadDhcpConfiguration(f)
 	if err != nil {
-		t.Fatalf("Unable to read dhcpd.conf sample: %s", err)
+		t.Fatalf("Failed to read dhcpd.conf sample: %s", err)
 	}
 
 	if len(config) != 3 {

--- a/builder/vmware/common/driver_workstation_windows.go
+++ b/builder/vmware/common/driver_workstation_windows.go
@@ -75,7 +75,7 @@ func workstationInstallationPath() (string, error) {
 func workstationDhcpLeasesPath(device string) string {
 	path, err := workstationDhcpLeasesPathRegistry()
 	if err != nil {
-		log.Printf("[WARN] Error finding leases in registry: %s", err)
+		log.Printf("[WARN] Failed to find leases in registry: %s", err)
 	} else if _, err := os.Stat(path); err == nil {
 		return path
 	}
@@ -130,7 +130,7 @@ func workstationAppendPath(paths []string, envVar, suffix string) []string {
 func workstationProgramFilePaths() []string {
 	path, err := workstationInstallationPath()
 	if err != nil {
-		log.Printf("[WARN] Unable to retrieve installation path from registry: %s", err)
+		log.Printf("[WARN] Failed to retrieve installation path from registry: %s", err)
 	}
 
 	paths := make([]string, 0, 5)
@@ -154,7 +154,7 @@ func workstationProgramFilePaths() []string {
 func workstationDataFilePaths() []string {
 	leasesPath, err := workstationDhcpLeasesPathRegistry()
 	if err != nil {
-		log.Printf("[WARN] Unable to retrieve DHCP leases path from registry: %s", err)
+		log.Printf("[WARN] Failed to retrieve DHCP leases path from registry: %s", err)
 	}
 
 	if leasesPath != "" {
@@ -197,7 +197,7 @@ func workstationGetVersionFromRegistry() (string, error) {
 		if err == nil {
 			return productVersion, nil
 		}
-		log.Printf(`[WARN] Unable to read registry key %s\%s`, path, subkey)
+		log.Printf(`[WARN] Failed to read registry key %s\%s`, path, subkey)
 	}
 	return "", fmt.Errorf("unable to read any valid registry key for VMware Workstation")
 }

--- a/builder/vmware/common/hw_config_test.go
+++ b/builder/vmware/common/hw_config_test.go
@@ -60,7 +60,7 @@ func TestHWConfigParallel_File(t *testing.T) {
 
 	parallel, err := c.ReadParallel()
 	if err != nil {
-		t.Fatalf("Unable to read parallel port definition: %s", err)
+		t.Fatalf("Failed to read parallel port definition: %s", err)
 	}
 
 	switch parallel.Union.(type) {
@@ -89,7 +89,7 @@ func TestHWConfigParallel_Device(t *testing.T) {
 
 	parallel, err := c.ReadParallel()
 	if err != nil {
-		t.Fatalf("Unable to read parallel port definition: %s", err)
+		t.Fatalf("Failed to read parallel port definition: %s", err)
 	}
 
 	switch parallel.Union.(type) {
@@ -122,7 +122,7 @@ func TestHWConfigParallel_Auto(t *testing.T) {
 
 	parallel, err := c.ReadParallel()
 	if err != nil {
-		t.Fatalf("Unable to read parallel port definition: %s", err)
+		t.Fatalf("Failed to read parallel port definition: %s", err)
 	}
 
 	switch parallel.Union.(type) {
@@ -151,7 +151,7 @@ func TestHWConfigParallel_None(t *testing.T) {
 
 	parallel, err := c.ReadParallel()
 	if err != nil {
-		t.Fatalf("Unable to read parallel port definition: %s", err)
+		t.Fatalf("Failed to read parallel port definition: %s", err)
 	}
 
 	if parallel.Union != nil {
@@ -173,7 +173,7 @@ func TestHWConfigSerial_File(t *testing.T) {
 
 	serial, err := c.ReadSerial()
 	if err != nil {
-		t.Fatalf("Unable to read serial port definition: %s", err)
+		t.Fatalf("Failed to read serial port definition: %s", err)
 	}
 
 	switch serial.Union.(type) {
@@ -206,7 +206,7 @@ func TestHWConfigSerial_Device(t *testing.T) {
 
 	serial, err := c.ReadSerial()
 	if err != nil {
-		t.Fatalf("Unable to read serial port definition: %s", err)
+		t.Fatalf("Failed to read serial port definition: %s", err)
 	}
 
 	switch serial.Union.(type) {
@@ -239,7 +239,7 @@ func TestHWConfigSerial_Pipe(t *testing.T) {
 
 	serial, err := c.ReadSerial()
 	if err != nil {
-		t.Fatalf("Unable to read serial port definition: %s", err)
+		t.Fatalf("Failed to read serial port definition: %s", err)
 	}
 
 	switch serial.Union.(type) {
@@ -280,7 +280,7 @@ func TestHWConfigSerial_Auto(t *testing.T) {
 
 	serial, err := c.ReadSerial()
 	if err != nil {
-		t.Fatalf("Unable to read serial port definition: %s", err)
+		t.Fatalf("Failed to read serial port definition: %s", err)
 	}
 
 	switch serial.Union.(type) {
@@ -309,7 +309,7 @@ func TestHWConfigSerial_None(t *testing.T) {
 
 	serial, err := c.ReadSerial()
 	if err != nil {
-		t.Fatalf("Unable to read serial port definition: %s", err)
+		t.Fatalf("Failed to read serial port definition: %s", err)
 	}
 
 	if serial.Union != nil {

--- a/builder/vmware/common/step_configure_vnc.go
+++ b/builder/vmware/common/step_configure_vnc.go
@@ -139,7 +139,7 @@ func (*StepConfigureVNC) UpdateVMX(address, password string, port int, data map[
 func (s *StepConfigureVNC) Cleanup(multistep.StateBag) {
 	if s.l != nil {
 		if err := s.l.Close(); err != nil {
-			log.Printf("failed to unlock port lockfile: %s", err)
+			log.Printf("[WARN] Failed to unlock port lockfile: %s", err)
 		}
 	}
 }

--- a/builder/vmware/common/step_output_dir.go
+++ b/builder/vmware/common/step_output_dir.go
@@ -120,7 +120,7 @@ func (s *StepOutputDir) Cleanup(state multistep.StateBag) {
 					break
 				}
 
-				log.Printf("Error removing output dir: %s", err)
+				log.Printf("[WARN] Failed to remove output dir: %s", err)
 				time.Sleep(2 * time.Second)
 			}
 		}

--- a/builder/vmware/common/step_remote_upload.go
+++ b/builder/vmware/common/step_remote_upload.go
@@ -76,9 +76,9 @@ func (s *StepRemoteUpload) Cleanup(state multistep.StateBag) {
 		return
 	}
 
-	log.Printf("[INFO]Cleaning up remote path: %s", path)
+	log.Printf("[INFO] Cleaning up remote path: %s", path)
 	err := remote.RemoveCache(path)
 	if err != nil {
-		log.Printf("[WARN] Error cleaning up: %s", err)
+		log.Printf("[WARN] Failed to clean up: %s", err)
 	}
 }

--- a/builder/vmware/common/step_shutdown.go
+++ b/builder/vmware/common/step_shutdown.go
@@ -62,8 +62,8 @@ func (s *StepShutdown) Run(ctx context.Context, state multistep.StateBag) multis
 
 			select {
 			case <-shutdownTimer:
-				log.Printf("Shutdown stdout: %s", stdout.String())
-				log.Printf("Shutdown stderr: %s", stderr.String())
+				log.Printf("[INFO] Shutdown stdout: %s", stdout.String())
+				log.Printf("[INFO] Shutdown stderr: %s", stderr.String())
 				err := errors.New("timeout waiting for virtual machine to shut down")
 				state.Put("error", err)
 				ui.Error(err.Error())
@@ -89,7 +89,7 @@ LockWaitLoop:
 	for {
 		files, err := dir.ListFiles()
 		if err != nil {
-			log.Printf("error listing files in output directory: %s", err)
+			log.Printf("[WARN] Failed to list files in output directory: %s", err)
 		} else {
 			var locks []string
 			for _, file := range files {


### PR DESCRIPTION
### Description

Standardizes and improves the clarity of log messages throughout the VMware builder codebase by updating the phrasing of log outputs and consistently adding log level prefixes (such as `[INFO]` and `[WARN]`). This helps make log output more uniform and easier to interpret, which is beneficial for both debugging and monitoring. Additionally, several test assertions have been updated to use clearer error messages.

* Added `[INFO]` and `[WARN]` prefixes to log messages in `driver.go`, `driver_esxi.go`, `driver_workstation_windows.go`, `step_configure_vnc.go`, `step_output_dir.go`, and `step_remote_upload.go`, ensuring consistent log levels and improved readability. [[1]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L309-R314) [[2]](diffhunk://#diff-8f3742296d271d46bcaf87a729a397511a26650932193454ee01af6f7444158bL127-R128) [[3]](diffhunk://#diff-98d454cc4a6238b356f64f067e816b88187d78d0ed79a45353c50c8211ed6676L78-R78) [[4]](diffhunk://#diff-a7be0e4040d9db035da63bda8eab49b7709bad1e74101a93bc2819e377a53700L142-R142) [[5]](diffhunk://#diff-5b1d168f7bddf205964e4635f0642067cdddecc695fc7107051e4d3fa77602e1L123-R123) [[6]](diffhunk://#diff-d6c8b6dfe782feb7407a15f208e32717468dcb1ae9969e87b7a2cb37358368b1L82-R82)
* Updated log message phrasing for error handling to use "Failed to..." instead of "Error..." or "Unable to...", making the messages more direct and standardized. [[1]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L524-R524) [[2]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L610-R610) [[3]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L569-R569) [[4]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L830-R830) [[5]](diffhunk://#diff-98d454cc4a6238b356f64f067e816b88187d78d0ed79a45353c50c8211ed6676L133-R133) [[6]](diffhunk://#diff-98d454cc4a6238b356f64f067e816b88187d78d0ed79a45353c50c8211ed6676L157-R157) [[7]](diffhunk://#diff-98d454cc4a6238b356f64f067e816b88187d78d0ed79a45353c50c8211ed6676L200-R200)
* Changed error messages in test assertions from "Unable to..." to "Failed to..." for improved clarity and consistency in `driver_parser_test.go` and `hw_config_test.go`. [[1]](diffhunk://#diff-a16dac2e287f395dd5ff5067787d1806d55769f854dbadea901e9458e65084d2L352-R358) [[2]](diffhunk://#diff-36d6bf8a75354631b8d2fa872940a3648bacbb2bef93f578bd81a8dc02013b1fL63-R63) [[3]](diffhunk://#diff-36d6bf8a75354631b8d2fa872940a3648bacbb2bef93f578bd81a8dc02013b1fL92-R92) [[4]](diffhunk://#diff-36d6bf8a75354631b8d2fa872940a3648bacbb2bef93f578bd81a8dc02013b1fL125-R125) [[5]](diffhunk://#diff-36d6bf8a75354631b8d2fa872940a3648bacbb2bef93f578bd81a8dc02013b1fL154-R154) [[6]](diffhunk://#diff-36d6bf8a75354631b8d2fa872940a3648bacbb2bef93f578bd81a8dc02013b1fL176-R176) [[7]](diffhunk://#diff-36d6bf8a75354631b8d2fa872940a3648bacbb2bef93f578bd81a8dc02013b1fL209-R209) [[8]](diffhunk://#diff-36d6bf8a75354631b8d2fa872940a3648bacbb2bef93f578bd81a8dc02013b1fL242-R242) [[9]](diffhunk://#diff-36d6bf8a75354631b8d2fa872940a3648bacbb2bef93f578bd81a8dc02013b1fL283-R283) [[10]](diffhunk://#diff-36d6bf8a75354631b8d2fa872940a3648bacbb2bef93f578bd81a8dc02013b1fL312-R312)
* Improved log messages to better describe actions and outcomes, such as device and MAC address discoveries, and cloning/uploading operations. [[1]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L459-R459) [[2]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L483-R483) [[3]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L501-R501) [[4]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L670-R670) [[5]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L688-R688) [[6]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L751-R751) [[7]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L769-R769) [[8]](diffhunk://#diff-8f3742296d271d46bcaf87a729a397511a26650932193454ee01af6f7444158bL171-R171) [[9]](diffhunk://#diff-8f3742296d271d46bcaf87a729a397511a26650932193454ee01af6f7444158bL266-R271) [[10]](diffhunk://#diff-8f3742296d271d46bcaf87a729a397511a26650932193454ee01af6f7444158bL288-R288) [[11]](diffhunk://#diff-8f3742296d271d46bcaf87a729a397511a26650932193454ee01af6f7444158bL355-R355)

These changes collectively make the codebase's logging and error reporting more consistent and easier to understand for future maintenance and debugging.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

Revert commit.

### Changes to Security Controls

None.