### PR TITLE
refactor: default guest os type based on architecture

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -62,7 +62,7 @@ JSON Example:
   Allowed values are `ide`, `sata`, and `scsi`.
 
 - `guest_os_type` (string) - The guest operating system identifier for the virtual machine.
-  Defaults to `other`.
+  Defaults to `other-64` on amd64 and `arm-other-64` on arm64.
 
 - `version` (int) - The virtual machine hardware version. Refer to [KB 315655](https://knowledge.broadcom.com/external/article?articleNumber=315655)
   for more information on supported virtual hardware versions.

--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -152,8 +152,13 @@ const (
 	defaultDiskName = "disk"
 	// defaultDiskAdapterType specifies the default disk adapter type for a virtual machine's primary disk.'
 	defaultDiskAdapterType = "lsilogic"
-	// DefaultGuestOsType specifies the default guest operating system type for a virtual machine.
-	DefaultGuestOsType = "other"
+	// DefaultGuestOsTypeAmd64 specifies the default guest operating system type for a virtual machine running on AMD64.
+	DefaultGuestOsTypeAmd64 = "other-64"
+	// DefaultGuestOsTypeArm64 specifies the default guest operating system type for a virtual machine running on ARM64.
+	DefaultGuestOsTypeArm64 = "arm-other-64"
+	// FallbackGuestOsType specifies the default guest operating system type for a virtual machine if the runtime
+	// architecture is not AMD64 or ARM64.
+	FallbackGuestOsType = "other"
 	// DefaultNetworkType specifies the default network type for a virtual machine.
 	DefaultNetworkType = "nat"
 )

--- a/docs-partials/builder/vmware/iso/Config-not-required.mdx
+++ b/docs-partials/builder/vmware/iso/Config-not-required.mdx
@@ -8,7 +8,7 @@
   Allowed values are `ide`, `sata`, and `scsi`.
 
 - `guest_os_type` (string) - The guest operating system identifier for the virtual machine.
-  Defaults to `other`.
+  Defaults to `other-64` on amd64 and `arm-other-64` on arm64.
 
 - `version` (int) - The virtual machine hardware version. Refer to [KB 315655](https://knowledge.broadcom.com/external/article?articleNumber=315655)
   for more information on supported virtual hardware versions.


### PR DESCRIPTION
### Description

Updates the default guest operating system identifier for virtual machines to be architecture-aware, improving compatibility and clarity for users on different platforms. The changes ensure that the default value for `guest_os_type` is set appropriately based on whether the runtime architecture is `amd64`, `arm64`, or something else, and updates documentation to reflect this behavior.

Guest OS Type Handling:

* Added architecture-specific constants for guest OS type: `DefaultGuestOsTypeAmd64` (`other-64`), `DefaultGuestOsTypeArm64` (`arm-other-64`), and a fallback value (`other`) in `builder/vmware/common/driver.go`.
* Updated logic in `builder/vmware/iso/config.go` so that if `guest_os_type` is not specified, it is set based on the runtime architecture, with a warning for unrecognized architectures.

Documentation Updates:

* Updated documentation in `.web-docs/components/builder/iso/README.md` and `docs-partials/builder/vmware/iso/Config-not-required.mdx` to clarify the new default values for `guest_os_type` based on architecture. [[1]](diffhunk://#diff-65e329d9f6a8d0aecefed129bf5c4d7f389b1b5875468ccd963c6fbade3b50d0L67-R67) [[2]](diffhunk://#diff-1fbe0b800ea8f24423d09a238773f05fba2807c8ac9865aa2994a6c663f564d6L11-R11) [[3]](diffhunk://#diff-6a22861e2ec726ec0cc6112f8892aacd7cc6f3a86c1c53cace1357f215fad35eL50-R51)
* Added `runtime` import in `builder/vmware/iso/config.go` to support architecture detection.

### Resolved Issues

Better default coverage with a default guest operating system identified based on system architecture if not provided.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.

