### PR TITLE
refactor: use constant for default network

### DIFF
--- a/builder/vmware/common/driver_parser.go
+++ b/builder/vmware/common/driver_parser.go
@@ -2106,7 +2106,7 @@ func (c NetworkingConfig) NameIntoDevices(name string) ([]string, error) {
 	if name == "hostonly" && len(netmapper[NetworkingTypeHostonly]) > 0 {
 		networkingType = NetworkingTypeHostonly
 
-	} else if name == "nat" && len(netmapper[NetworkingTypeNat]) > 0 {
+	} else if name == DefaultNetworkType && len(netmapper[NetworkingTypeNat]) > 0 {
 		networkingType = NetworkingTypeNat
 
 	} else if name == "bridged" && len(netmapper[NetworkingTypeBridged]) > 0 {

--- a/builder/vmware/iso/config.go
+++ b/builder/vmware/iso/config.go
@@ -171,7 +171,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	}
 
 	if c.Network == "" {
-		c.Network = "nat"
+		c.Network = vmwcommon.DefaultNetworkType
 	}
 
 	if c.Format == "" {

--- a/builder/vmware/vmx/step_clone_vmx_test.go
+++ b/builder/vmware/vmx/step_clone_vmx_test.go
@@ -100,7 +100,7 @@ func TestStepCloneVMX(t *testing.T) {
 	// Test we got the network type
 	if networkType, ok := state.GetOk("vmnetwork"); !ok {
 		t.Fatal("should set vmnetwork")
-	} else if networkType != "nat" {
+	} else if networkType != vmwcommon.DefaultNetworkType {
 		t.Fatalf("bad network type: %#v", networkType)
 	}
 }


### PR DESCRIPTION
### Description

Updates the handling of default network types in the builder components to use a centralized constant, improving maintainability and consistency across the codebase. The main changes involve replacing hardcoded `"nat"` strings with the `DefaultNetworkType` constant from the `common` package.

Networking configuration consistency:

* Replaced the hardcoded `"nat"` string with `DefaultNetworkType` in the logic that maps network names to device types in `driver_parser.go`, ensuring consistent use of the default network type.
* Updated the default assignment for the network type in `iso/config.go` to use `DefaultNetworkType` instead of the string `"nat"`.

Test improvements:

* Modified the network type check in `step_clone_vmx_test.go` to compare against `DefaultNetworkType` rather than the string `"nat"`, ensuring tests remain valid if the default changes.

### Resolved Issues

improving maintainability and consistency across the codebase for the default network type.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
