### PR TITLE
refactor: fusion preferences path constant

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -36,6 +36,7 @@ const (
 	fusionMinVersion      = "13.5.0"
 	fusionAppPath         = "/Applications/VMware Fusion.app"
 	fusionAppPathVariable = "FUSION_APP_PATH"
+	fusionPreferencesPath = "/Library/Preferences/VMware Fusion"
 	fusionSuppressPlist   = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/builder/vmware/common/driver_fusion.go
+++ b/builder/vmware/common/driver_fusion.go
@@ -157,7 +157,7 @@ func (d *FusionDriver) SuppressMessages(vmxPath string) error {
 }
 
 func (d *FusionDriver) libPath() string {
-	return filepath.Join("/", "Library", "Preferences", "VMware Fusion")
+	return fusionPreferencesPath
 }
 
 func (d *FusionDriver) binaryPath(binaryName string) string {


### PR DESCRIPTION
### Description

This pull request makes a small improvement to the way the Fusion preferences path is handled in the VMware Fusion driver code. The change centralizes the definition of the preferences path by introducing a new constant and updating its usage.

Added the `fusionPreferencesPath` constant in `driver.go` and updated the `libPath()` method in `driver_fusion.go` to use this constant instead of hardcoding the path. [[1]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3R39) [[2]](diffhunk://#diff-064807a60c8abca4575708b28ed413bc78aadd53ada1be0dae276089b51fd5feL160-R160)

### Resolved Issues

This improves maintainability and consistency for path references.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
