### PR TITLE
refactor: remove fusion technical preview

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -91,9 +91,8 @@ const (
 	appVmx          = "vmware-vmx"
 
 	// Version regular expressions.
-	productVersionRegex   = `(?i)VMware [a-z0-9-]+ (\d+\.\d+\.\d+)`
-	technicalPreviewRegex = `(?i)VMware [a-z0-9-]+ e\.x\.p `
-	ovfToolVersionRegex   = `\d+\.\d+\.\d+`
+	productVersionRegex = `(?i)VMware [a-z0-9-]+ (\d+\.\d+\.\d+)`
+	ovfToolVersionRegex = `\d+\.\d+\.\d+`
 
 	// File names.
 	dhcpVmnetConfFile   = "vmnetdhcp.conf"
@@ -211,9 +210,6 @@ var skipCleanFileExtensions = []string{
 
 // The product version.
 var productVersion = regexp.MustCompile(productVersionRegex)
-
-// The technical preview version.
-var technicalPreview = regexp.MustCompile(technicalPreviewRegex)
 
 // The VMware OVF Tool version.
 var ovfToolVersion = regexp.MustCompile(ovfToolVersionRegex)

--- a/builder/vmware/common/driver_fusion.go
+++ b/builder/vmware/common/driver_fusion.go
@@ -333,13 +333,6 @@ func (d *FusionDriver) getFusionVersion() (*version.Version, error) {
 		return nil, fmt.Errorf("error getting version: %w", err)
 	}
 
-	// Check for Tech Preview version.
-	if matches := technicalPreview.FindStringSubmatch(stderr.String()); matches != nil {
-		log.Printf("[INFO] %s: e.x.p (Tech Preview)", fusionProductName)
-		return version.NewVersion("0.0.0-e.x.p")
-	}
-
-	// Check for generally available version.
 	versionMatch := productVersion.FindStringSubmatch(stderr.String())
 	if versionMatch == nil {
 		return nil, fmt.Errorf("error parsing version from output: %s", stderr.String())


### PR DESCRIPTION
### Description

Removes the detection and handling of technical preview versions in the VMware Fusion driver code. The logic and regular expression for identifying technical preview versions builds have been eliminated, so only generally available versions are now parsed.

* Removed the `technicalPreviewRegex` constant and its associated `technicalPreview` regular expression from `builder/vmware/common/driver.go`, so "Tech Preview" versions are no longer recognized. [[1]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L95) [[2]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3L215-L217)
* Deleted the code in `getFusionVersion` in `builder/vmware/common/driver_fusion.go` that checked for and handled "Tech Preview" versions, simplifying version parsing to only support standard releases.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

Reverty commit.

### Changes to Security Controls

None.