### PR TITLE
chore: bump minimum versions

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -33,7 +33,7 @@ const (
 
 	// VMware Fusion.
 	fusionProductName     = "VMware Fusion"
-	fusionMinVersion      = "13.5.0"
+	fusionMinVersion      = "13.6.0"
 	fusionAppPath         = "/Applications/VMware Fusion.app"
 	fusionAppPathVariable = "FUSION_APP_PATH"
 	fusionPreferencesPath = "/Library/Preferences/VMware Fusion"
@@ -48,7 +48,7 @@ const (
 
 	// VMware Workstation.
 	workstationProductName      = "VMware Workstation"
-	workstationMinVersion       = "17.5.0"
+	workstationMinVersion       = "17.6.0"
 	workstationNoLicenseVersion = "17.6.2"
 	// Notes:
 	// Version 17.6.1 required a license key for commercial use but not for personal use.


### PR DESCRIPTION
### Description

This pull request updates the minimum required versions for VMware Fusion and VMware Workstation in the `builder/vmware/common/driver.go` file. 

* Increased the minimum supported version for VMware Fusion from `13.5.0` to `13.6.0` (`fusionMinVersion`).
* Increased the minimum supported version for VMware Workstation from `17.5.0` to `17.6.0` (`workstationMinVersion`).

These changes ensure compatibility with the more current releases of both desktop hypervisor products.

The existing `compareVersionObjects` function will compare the version required and the version returned to ensure that the found version meets or exceeds the required version. If not, an error will be returned:
 
```go
	if versionFound.LessThan(versionRequired) {
		return fmt.Errorf("[ERROR] Requires %s %s or later; %s installed", product, versionRequired.String(), versionFound.String())
	}
```

For example: 

```shell
[ERROR] Requires 13.6.0 or later; 13.5.1 installed
```

```shell
[ERROR] Requires 17.6.0 or later; 17.4.0 installed
```

References:

- [VMware Workstation 17.6.x Release Notes](https://techdocs.broadcom.com/us/en/vmware-cis/desktop-hypervisors/workstation-pro/17-0/release-notes/vmware-workstation-176-pro-release-notes.html)
- [VMware Fusion 13.6.x Release Notes](https://techdocs.broadcom.com/us/en/vmware-cis/desktop-hypervisors/fusion-pro/13-0/release-notes/vmware-fusion-136-release-notes.html)

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
