### PR TITLE
chore: update virtual hardware versions

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -66,7 +66,7 @@ JSON Example:
 
 - `version` (int) - The virtual machine hardware version. Refer to [KB 315655](https://knowledge.broadcom.com/external/article?articleNumber=315655)
   for more information on supported virtual hardware versions.
-  Minimum is 13. Default is 19.
+  Default is 21. Minimum is 19.
 
 - `vm_name` (string) - The name of the virtual machine. This represents the name of the virtual
   machine `.vmx` configuration file without the file extension.

--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -139,9 +139,9 @@ const (
 	toolsFlavorWindows = osWindows
 
 	// MinimumHardwareVersion specifies the minimum supported hardware version required for compatibility.
-	MinimumHardwareVersion = 13
+	MinimumHardwareVersion = 19
 	// DefaultHardwareVersion specifies the default virtual hardware version used during virtual machine creation.
-	DefaultHardwareVersion = 19
+	DefaultHardwareVersion = 21
 	// DefaultMemorySize specifies the default memory size (in MB) for a virtual machine configuration.
 	DefaultMemorySize = 512
 	// DefaultDiskSize specifies the default size, in megabytes, allocated for a virtual machine's primary disk.

--- a/builder/vmware/iso/config.go
+++ b/builder/vmware/iso/config.go
@@ -51,7 +51,7 @@ type Config struct {
 	GuestOSType string `mapstructure:"guest_os_type" required:"false"`
 	// The virtual machine hardware version. Refer to [KB 315655](https://knowledge.broadcom.com/external/article?articleNumber=315655)
 	// for more information on supported virtual hardware versions.
-	// Minimum is 13. Default is 19.
+	// Default is 21. Minimum is 19.
 	Version int `mapstructure:"version" required:"false"`
 	// The name of the virtual machine. This represents the name of the virtual
 	// machine `.vmx` configuration file without the file extension.

--- a/docs-partials/builder/vmware/iso/Config-not-required.mdx
+++ b/docs-partials/builder/vmware/iso/Config-not-required.mdx
@@ -12,7 +12,7 @@
 
 - `version` (int) - The virtual machine hardware version. Refer to [KB 315655](https://knowledge.broadcom.com/external/article?articleNumber=315655)
   for more information on supported virtual hardware versions.
-  Minimum is 13. Default is 19.
+  Default is 21. Minimum is 19.
 
 - `vm_name` (string) - The name of the virtual machine. This represents the name of the virtual
   machine `.vmx` configuration file without the file extension.


### PR DESCRIPTION
### Description

Updated the minimum supported hardware version from 13 to 19 and the default from 19 to 21 in the `vmware-iso` builder.

Reference: https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html

* Increased the minimum supported hardware version from 13 to 19 and the default hardware version from 19 to 21 in the `Config` struct documentation in `builder/vmware/iso/config.go`.
* Updated the constants `MinimumHardwareVersion` and `DefaultHardwareVersion` in `builder/vmware/common/driver.go` to match the new requirements.

Documentation consistency:

* Updated the hardware version information in `docs-partials/builder/vmware/iso/Config-not-required.mdx` for consistency with the code changes.

### Resolved Issues

Ensure consistency and reflect supported versions in #369.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.

