### PR TITLE
[wip] refactor: require network adapter type

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -127,11 +127,12 @@ JSON Example:
 - `network_name` (string) - The network which the virtual machine will connect on a remote
   hypervisor.
 
-- `network_adapter_type` (string) - The virtual machine network card type. Recommended values are `e1000` and
-  `vmxnet3`. Defaults to `e1000`.
+- `network_adapter_type` (string) - The network adapter type for the virtual machine.
+  Allowed values are `vmxnet3`, `e1000e`, and `e1000`
   
-  Refer to VMware product documentation for supported network adapter types
-  for the hypervisor and guest operating system.
+  Refer to the VMware desktop hypervisor product documentation for
+  the network adapter types supported by the guest operating system
+  and the CPU architecture (`amd64/x86_64` vs `arm64/aarch64`).
 
 - `sound` (bool) - Enable virtual sound card device. Defaults to `false`.
 

--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -116,6 +116,11 @@ const (
 	// FirmwareTypeUEFISecure represents a constant for the UEFI firmware with secure boot type identifier.
 	FirmwareTypeUEFISecure = "efi-secure"
 
+	// Network adapter types.
+	networkAdapterE1000   = "e1000"
+	networkAdapterE1000E  = "e1000e"
+	networkAdapterVmxnet3 = "vmxnet3"
+
 	// Shutdown operation timings.
 	shutdownPollInterval     = 150 * time.Millisecond
 	shutdownLockTimeout      = 120 * time.Second
@@ -152,8 +157,6 @@ const (
 	DefaultGuestOsType = "other"
 	// DefaultNetworkType specifies the default network type for a virtual machine.
 	DefaultNetworkType = "nat"
-	// DefaultNetworkAdapterType specifies the default network adapter type for a virtual machine.
-	DefaultNetworkAdapterType = "e1000"
 )
 
 // Versions for supported or required components.
@@ -175,6 +178,13 @@ var allowedFirmwareTypes = []string{
 	FirmwareTypeBios,
 	FirmwareTypeUEFI,
 	FirmwareTypeUEFISecure,
+}
+
+// The allowed network adapter types for a virtual machine.
+var allowedNetworkAdapterTypes = []string{
+	networkAdapterVmxnet3,
+	networkAdapterE1000E,
+	networkAdapterE1000,
 }
 
 // The allowed values for the `ToolsUploadFlavor`.

--- a/builder/vmware/common/hw_config.go
+++ b/builder/vmware/common/hw_config.go
@@ -36,11 +36,12 @@ type HWConfig struct {
 	// The network which the virtual machine will connect on a remote
 	// hypervisor.
 	NetworkName string `mapstructure:"network_name" required:"false"`
-	// The virtual machine network card type. Recommended values are `e1000` and
-	// `vmxnet3`. Defaults to `e1000`.
+	// The network adapter type for the virtual machine.
+	// Allowed values are `vmxnet3`, `e1000e`, and `e1000`
 	//
-	// Refer to VMware product documentation for supported network adapter types
-	// for the hypervisor and guest operating system.
+	// Refer to the VMware desktop hypervisor product documentation for
+	// the network adapter types supported by the guest operating system
+	// and the CPU architecture (`amd64/x86_64` vs `arm64/aarch64`).
 	NetworkAdapterType string `mapstructure:"network_adapter_type" required:"false"`
 	// Enable virtual sound card device. Defaults to `false`.
 	Sound bool `mapstructure:"sound" required:"false"`
@@ -128,6 +129,10 @@ func (c *HWConfig) Prepare(ctx *interpolate.Context) []error {
 
 	if c.MemorySize < 0 {
 		errs = append(errs, fmt.Errorf("invalid amount of memory specified (memory < 0): %d", c.MemorySize))
+	}
+
+	if (c.NetworkAdapterType != "") && (!slices.Contains(allowedNetworkAdapterTypes, c.NetworkAdapterType)) {
+		errs = append(errs, fmt.Errorf("invalid 'network_adapter_type' type specified: %s; must be one of %s", c.NetworkAdapterType, strings.Join(allowedNetworkAdapterTypes, ", ")))
 	}
 
 	// Peripherals

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -172,7 +172,7 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 		DiskName:       config.DiskName,
 		Version:        strconv.Itoa(config.Version),
 		ISOPath:        isoPath,
-		NetworkAdapter: common.DefaultNetworkAdapterType,
+		NetworkAdapter: config.NetworkAdapterType,
 
 		SoundPresent: map[bool]string{true: "TRUE", false: "FALSE"}[config.Sound],
 		UsbPresent:   map[bool]string{true: "TRUE", false: "FALSE"}[config.USB],

--- a/docs-partials/builder/vmware/common/HWConfig-not-required.mdx
+++ b/docs-partials/builder/vmware/common/HWConfig-not-required.mdx
@@ -20,11 +20,12 @@
 - `network_name` (string) - The network which the virtual machine will connect on a remote
   hypervisor.
 
-- `network_adapter_type` (string) - The virtual machine network card type. Recommended values are `e1000` and
-  `vmxnet3`. Defaults to `e1000`.
+- `network_adapter_type` (string) - The network adapter type for the virtual machine.
+  Allowed values are `vmxnet3`, `e1000e`, and `e1000`
   
-  Refer to VMware product documentation for supported network adapter types
-  for the hypervisor and guest operating system.
+  Refer to the VMware desktop hypervisor product documentation for
+  the network adapter types supported by the guest operating system
+  and the CPU architecture (`amd64/x86_64` vs `arm64/aarch64`).
 
 - `sound` (bool) - Enable virtual sound card device. Defaults to `false`.
 


### PR DESCRIPTION
### Description

> [!WARNING]
> The `network_adapter_type` must be provided based on the guest operating system and CPU architecture of the host operating system for the desktop hypervisor based on allowed network adapter types (`vmxnet3`, `e1000e`, and `e1000`). A default of `e1000` is **not** appropriate.
>
> This is a **breaking change** and requires a major version release.

This pull request enforces which network adapter types are supported for virtual machines, improves documentation, and adds validation logic. The changes ensure users can only select from the officially supported adapter types, and the documentation now reflects these options more clearly.

* Added a new list of allowed network adapter types (`vmxnet3`, `e1000e`, and `e1000`) and enforced validation in `HWConfig.Prepare` to prevent unsupported values. [[1]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3R119-R123) [[2]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3R183-R189) [[3]](diffhunk://#diff-5abb38f2f9b2a09eef799c250f9db4cd18a48b5a84cb4a4f458e427d4798bdbeR134-R137)
* Updated the `network_adapter_type` field in `HWConfig` and related documentation to specify the allowed values and clarify compatibility guidance. [[1]](diffhunk://#diff-5abb38f2f9b2a09eef799c250f9db4cd18a48b5a84cb4a4f458e427d4798bdbeL39-R44) [[2]](diffhunk://#diff-385cd576c6630a4d1e75fc453a45cb7db87745eb569e59f5bb5ee452cb1cb104L23-R28) [[3]](diffhunk://#diff-65e329d9f6a8d0aecefed129bf5c4d7f389b1b5875468ccd963c6fbade3b50d0L130-R135)
* Changed creation logic to use the user-specified adapter type rather than a hardcoded default, ensuring correct configuration in generated VMX files.
* Removed the default network adapter type constant, as the adapter type is now explicitly set by the user.

### Resolved Issues

Closes #260

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
