### PR TITLE
fix: attach custom cd for `cd_files`

### DIFF
--- a/.web-docs/components/builder/vmx/README.md
+++ b/.web-docs/components/builder/vmx/README.md
@@ -63,6 +63,10 @@ JSON Example:
 
 <!-- Code generated from the comments of the Config struct in builder/vmware/vmx/config.go; DO NOT EDIT MANUALLY -->
 
+- `cdrom_adapter_type` (string) - The type of controller to use for the CD-ROM device. Allowed values are
+  `ide`, `sata`, and `scsi`. If not specified, the plugin will attempt to
+  determine the appropriate adapter type.
+
 - `linked` (bool) - By default, the plugin creates a 'full' clone of the virtual machine
   specified in `source_path`. The resultant virtual machine is fully
   independent of the parent it was cloned from.

--- a/builder/vmware/common/step_configure_vmx.go
+++ b/builder/vmware/common/step_configure_vmx.go
@@ -84,12 +84,18 @@ func (s *StepConfigureVMX) Run(ctx context.Context, state multistep.StateBag) mu
 			if cdPath != "" {
 				diskAndCDConfigData := DefaultDiskAndCDROMTypes(s.DiskAdapterType, s.CDROMAdapterType)
 				cdromPrefix := diskAndCDConfigData.CdromType + "1:" + diskAndCDConfigData.CdromTypePrimarySecondary
+
+				// Ensure the CD-ROM adapter is present.
+				adapterKey := diskAndCDConfigData.CdromType + "1.present"
+				vmxData[adapterKey] = "TRUE"
+
+				// Configure the CD-ROM device.
 				vmxData[cdromPrefix+".present"] = "TRUE"
 				vmxData[cdromPrefix+".filename"] = cdPath.(string)
 				vmxData[cdromPrefix+".devicetype"] = "cdrom-image"
 
-				// Add it to our list of build devices to later remove
-				tmpBuildDevices = append(tmpBuildDevices, cdromPrefix)
+				// Add both the adapter and device to our list of build devices to later remove.
+				tmpBuildDevices = append(tmpBuildDevices, adapterKey, cdromPrefix)
 			}
 		}
 

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -115,7 +115,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			VMName:           b.config.VMName,
 			DisplayName:      b.config.VMXDisplayName,
 			DiskAdapterType:  b.config.DiskAdapterType,
-			CDROMAdapterType: "",
+			CDROMAdapterType: b.config.CdromAdapterType,
 		},
 		&vmwcommon.StepSuppressMessages{},
 		&vmwcommon.StepHTTPIPDiscover{},

--- a/builder/vmware/vmx/config.hcl2spec.go
+++ b/builder/vmware/vmx/config.hcl2spec.go
@@ -125,6 +125,7 @@ type FlatConfig struct {
 	DiskAdapterType           *string           `mapstructure:"disk_adapter_type" required:"false" cty:"disk_adapter_type" hcl:"disk_adapter_type"`
 	DiskName                  *string           `mapstructure:"vmdk_name" required:"false" cty:"vmdk_name" hcl:"vmdk_name"`
 	DiskTypeId                *string           `mapstructure:"disk_type_id" required:"false" cty:"disk_type_id" hcl:"disk_type_id"`
+	CdromAdapterType          *string           `mapstructure:"cdrom_adapter_type" required:"false" cty:"cdrom_adapter_type" hcl:"cdrom_adapter_type"`
 	Linked                    *bool             `mapstructure:"linked" required:"false" cty:"linked" hcl:"linked"`
 	AttachSnapshot            *string           `mapstructure:"attach_snapshot" required:"false" cty:"attach_snapshot" hcl:"attach_snapshot"`
 	SourcePath                *string           `mapstructure:"source_path" required:"true" cty:"source_path" hcl:"source_path"`
@@ -259,6 +260,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disk_adapter_type":              &hcldec.AttrSpec{Name: "disk_adapter_type", Type: cty.String, Required: false},
 		"vmdk_name":                      &hcldec.AttrSpec{Name: "vmdk_name", Type: cty.String, Required: false},
 		"disk_type_id":                   &hcldec.AttrSpec{Name: "disk_type_id", Type: cty.String, Required: false},
+		"cdrom_adapter_type":             &hcldec.AttrSpec{Name: "cdrom_adapter_type", Type: cty.String, Required: false},
 		"linked":                         &hcldec.AttrSpec{Name: "linked", Type: cty.Bool, Required: false},
 		"attach_snapshot":                &hcldec.AttrSpec{Name: "attach_snapshot", Type: cty.String, Required: false},
 		"source_path":                    &hcldec.AttrSpec{Name: "source_path", Type: cty.String, Required: false},

--- a/docs-partials/builder/vmware/vmx/Config-not-required.mdx
+++ b/docs-partials/builder/vmware/vmx/Config-not-required.mdx
@@ -1,5 +1,9 @@
 <!-- Code generated from the comments of the Config struct in builder/vmware/vmx/config.go; DO NOT EDIT MANUALLY -->
 
+- `cdrom_adapter_type` (string) - The type of controller to use for the CD-ROM device. Allowed values are
+  `ide`, `sata`, and `scsi`. If not specified, the plugin will attempt to
+  determine the appropriate adapter type.
+
 - `linked` (bool) - By default, the plugin creates a 'full' clone of the virtual machine
   specified in `source_path`. The resultant virtual machine is fully
   independent of the parent it was cloned from.


### PR DESCRIPTION
### Description

Fixes the issue attaching a custom CD when `cd_files` is used.

Closes #15
Closes #182
