### PR TITLE
refactor: update network adapter type validation

### DIFF
--- a/builder/vmware/common/hw_config.go
+++ b/builder/vmware/common/hw_config.go
@@ -131,7 +131,9 @@ func (c *HWConfig) Prepare(ctx *interpolate.Context) []error {
 		errs = append(errs, fmt.Errorf("invalid amount of memory specified (memory < 0): %d", c.MemorySize))
 	}
 
-	if (c.NetworkAdapterType != "") && (!slices.Contains(allowedNetworkAdapterTypes, c.NetworkAdapterType)) {
+	if c.NetworkAdapterType == "" {
+		errs = append(errs, fmt.Errorf("'network_adapter_type' is required; must be one of %s", strings.Join(allowedNetworkAdapterTypes, ", ")))
+	} else if !slices.Contains(allowedNetworkAdapterTypes, c.NetworkAdapterType) {
 		errs = append(errs, fmt.Errorf("invalid 'network_adapter_type' type specified: %s; must be one of %s", c.NetworkAdapterType, strings.Join(allowedNetworkAdapterTypes, ", ")))
 	}
 

--- a/builder/vmware/common/hw_config_test.go
+++ b/builder/vmware/common/hw_config_test.go
@@ -13,6 +13,8 @@ import (
 func TestHWConfigPrepare(t *testing.T) {
 	c := new(HWConfig)
 
+	c.NetworkAdapterType = "vmxnet3"
+
 	if errs := c.Prepare(interpolate.NewContext()); len(errs) > 0 {
 		t.Fatalf("err: %#v", errs)
 	}
@@ -48,6 +50,7 @@ func TestHWConfigPrepare(t *testing.T) {
 
 func TestHWConfigParallel_File(t *testing.T) {
 	c := new(HWConfig)
+	c.NetworkAdapterType = "vmxnet3"
 
 	c.Parallel = "file:filename"
 	if errs := c.Prepare(interpolate.NewContext()); len(errs) > 0 {
@@ -77,6 +80,7 @@ func TestHWConfigParallel_File(t *testing.T) {
 
 func TestHWConfigParallel_Device(t *testing.T) {
 	c := new(HWConfig)
+	c.NetworkAdapterType = "vmxnet3"
 
 	c.Parallel = "device:devicename,uni"
 	if errs := c.Prepare(interpolate.NewContext()); len(errs) > 0 {
@@ -110,6 +114,7 @@ func TestHWConfigParallel_Device(t *testing.T) {
 
 func TestHWConfigParallel_Auto(t *testing.T) {
 	c := new(HWConfig)
+	c.NetworkAdapterType = "vmxnet3"
 
 	c.Parallel = "auto:bi"
 	if errs := c.Prepare(interpolate.NewContext()); len(errs) > 0 {
@@ -139,6 +144,7 @@ func TestHWConfigParallel_Auto(t *testing.T) {
 
 func TestHWConfigParallel_None(t *testing.T) {
 	c := new(HWConfig)
+	c.NetworkAdapterType = "vmxnet3"
 
 	c.Parallel = "none"
 	if errs := c.Prepare(interpolate.NewContext()); len(errs) > 0 {
@@ -161,6 +167,7 @@ func TestHWConfigParallel_None(t *testing.T) {
 
 func TestHWConfigSerial_File(t *testing.T) {
 	c := new(HWConfig)
+	c.NetworkAdapterType = "vmxnet3"
 
 	c.Serial = "file:filename,true"
 	if errs := c.Prepare(interpolate.NewContext()); len(errs) > 0 {
@@ -194,6 +201,7 @@ func TestHWConfigSerial_File(t *testing.T) {
 
 func TestHWConfigSerial_Device(t *testing.T) {
 	c := new(HWConfig)
+	c.NetworkAdapterType = "vmxnet3"
 
 	c.Serial = "device:devicename,true"
 	if errs := c.Prepare(interpolate.NewContext()); len(errs) > 0 {
@@ -227,6 +235,7 @@ func TestHWConfigSerial_Device(t *testing.T) {
 
 func TestHWConfigSerial_Pipe(t *testing.T) {
 	c := new(HWConfig)
+	c.NetworkAdapterType = "vmxnet3"
 
 	c.Serial = "pipe:mypath,client,app,true"
 	if errs := c.Prepare(interpolate.NewContext()); len(errs) > 0 {
@@ -268,6 +277,7 @@ func TestHWConfigSerial_Pipe(t *testing.T) {
 
 func TestHWConfigSerial_Auto(t *testing.T) {
 	c := new(HWConfig)
+	c.NetworkAdapterType = "vmxnet3"
 
 	c.Serial = "auto:true"
 	if errs := c.Prepare(interpolate.NewContext()); len(errs) > 0 {
@@ -297,6 +307,7 @@ func TestHWConfigSerial_Auto(t *testing.T) {
 
 func TestHWConfigSerial_None(t *testing.T) {
 	c := new(HWConfig)
+	c.NetworkAdapterType = "vmxnet3"
 
 	c.Serial = "none"
 	if errs := c.Prepare(interpolate.NewContext()); len(errs) > 0 {

--- a/builder/vmware/iso/builder_test.go
+++ b/builder/vmware/iso/builder_test.go
@@ -17,11 +17,12 @@ import (
 
 func testConfig() map[string]interface{} {
 	return map[string]interface{}{
-		"version":          21,
-		"iso_checksum":     "md5:0B0F137F17AC10944716020B018F8126",
-		"iso_url":          "http://www.packer.io",
-		"shutdown_command": "foo",
-		"ssh_username":     "foo",
+		"version":              21,
+		"iso_checksum":         "md5:0B0F137F17AC10944716020B018F8126",
+		"iso_url":              "http://www.packer.io",
+		"shutdown_command":     "foo",
+		"ssh_username":         "foo",
+		"network_adapter_type": "vmxnet3",
 
 		common.BuildNameConfigKey: "foo",
 	}


### PR DESCRIPTION
### Description

Adds a check to ensure 'network_adapter_type' is provided and is one of the allowed values. IN my prior change, only invalid values were checked; now missing value are also reported as error.

**Example w/o 'network_adapter_type' provided:**

```shell
packer-plugin-vmware/example on  main [!?] via 🐹 v1.25.0 took 6.1s 
✦ ➜ packer build -var-file=pkrvars/debian/fusion-13.pkrvars.hcl .
Error: 1 error(s) occurred:

* 'network_adapter_type' is required; must be one of vmxnet3, e1000e, e1000

  on sources.pkr.hcl line 9:
  (source code not available)
```

**Example w/ an invalid option for 'network_adapter_type' provided:**

```shell
packer-plugin-vmware/example on  main [!?] via 🐹 v1.25.0 
✦ ➜ packer build -var-file=pkrvars/debian/fusion-13.pkrvars.hcl .
Error: 1 error(s) occurred:

* invalid 'network_adapter_type' type specified: foo; must be one of vmxnet3, e1000e, e1000

  on sources.pkr.hcl line 9:
  (source code not available)
```

**Plugin Tests:**

```shell
packer-plugin-vmware on  refactor/update-network-adapter-type-validation [!] via 🐹 v1.25.0 
✦2 ➜ make test
?       github.com/hashicorp/packer-plugin-vmware       [no test files]
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/common 6.505s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/iso    1.373s
ok      github.com/hashicorp/packer-plugin-vmware/builder/vmware/vmx    1.642s
?       github.com/hashicorp/packer-plugin-vmware/version       [no test files]
```