### PR TITLE
chore: remove unused constant

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -23,8 +23,7 @@ import (
 
 const (
 	// Builder ID.
-	builderId    = "vmware.desktop"
-	builderIdESX = "vmware.esx"
+	builderId = "vmware.desktop"
 
 	// Artifact configuration keys.
 	artifactConfFormat     = "artifact.conf.format"


### PR DESCRIPTION
### Description

Minor change to the `builder/vmware/common/driver.go` file, removing the unused `builderIdESX` constant. This helps clean up the code by eliminating unnecessary definitions.