### PR TITLE
refactor: require `usb_version` with `usb`

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -134,11 +134,17 @@ JSON Example:
 
 - `sound` (bool) - Enable virtual sound card device. Defaults to `false`.
 
-- `usb` (bool) - Enable USB 2.0 controllers for the virtual machine.
+- `usb` (bool) - Enable USB controller for the virtual machine.
   Defaults to `false`.
   
-  ~> **Note:** To enable USB 3.0 controllers, set a `usb_xhci.present`
-  key to `true` in the `vmx_data` option.
+  ~> **Note:** Automatically enabled on Apple Silicon-based systems to
+  ensure plugin functionality.
+
+- `usb_version` (string) - USB version to use when USB is enabled. Defaults to "2.0".
+  Allowed values are "2.0" and "3.1".
+  
+  ~> **Note:** Automatically set on Apple Silicon-based systems to ensure
+  plugin functionality.
 
 - `serial` (string) - Add a serial port to the virtual machine. Use a format of
   `Type:option1,option2,...`. Allowed values for the field `Type` include:

--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -124,6 +124,10 @@ const (
 	cdromAdapterSata = "sata"
 	cdromAdapterScsi = "scsi"
 
+	// USB version types.
+	UsbVersion20 = "2.0"
+	UsbVersion31 = "3.1"
+
 	// Shutdown operation timings.
 	shutdownPollInterval     = 150 * time.Millisecond
 	shutdownLockTimeout      = 120 * time.Second
@@ -200,6 +204,12 @@ var AllowedCdromAdapterTypes = []string{
 	cdromAdapterIde,
 	cdromAdapterSata,
 	cdromAdapterScsi,
+}
+
+// AllowedUsbVersions defines the allowed USB versions for a virtual machine.
+var AllowedUsbVersions = []string{
+	UsbVersion20,
+	UsbVersion31,
 }
 
 // The allowed values for the `ToolsUploadFlavor`.

--- a/builder/vmware/iso/config.hcl2spec.go
+++ b/builder/vmware/iso/config.hcl2spec.go
@@ -53,6 +53,7 @@ type FlatConfig struct {
 	NetworkAdapterType             *string           `mapstructure:"network_adapter_type" required:"false" cty:"network_adapter_type" hcl:"network_adapter_type"`
 	Sound                          *bool             `mapstructure:"sound" required:"false" cty:"sound" hcl:"sound"`
 	USB                            *bool             `mapstructure:"usb" required:"false" cty:"usb" hcl:"usb"`
+	USBVersion                     *string           `mapstructure:"usb_version" required:"false" cty:"usb_version" hcl:"usb_version"`
 	Serial                         *string           `mapstructure:"serial" required:"false" cty:"serial" hcl:"serial"`
 	Parallel                       *string           `mapstructure:"parallel" required:"false" cty:"parallel" hcl:"parallel"`
 	OutputDir                      *string           `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
@@ -193,6 +194,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"network_adapter_type":           &hcldec.AttrSpec{Name: "network_adapter_type", Type: cty.String, Required: false},
 		"sound":                          &hcldec.AttrSpec{Name: "sound", Type: cty.Bool, Required: false},
 		"usb":                            &hcldec.AttrSpec{Name: "usb", Type: cty.Bool, Required: false},
+		"usb_version":                    &hcldec.AttrSpec{Name: "usb_version", Type: cty.String, Required: false},
 		"serial":                         &hcldec.AttrSpec{Name: "serial", Type: cty.String, Required: false},
 		"parallel":                       &hcldec.AttrSpec{Name: "parallel", Type: cty.String, Required: false},
 		"output_directory":               &hcldec.AttrSpec{Name: "output_directory", Type: cty.String, Required: false},

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -40,6 +40,7 @@ type vmxTemplateData struct {
 
 	SoundPresent string
 	UsbPresent   string
+	UsbVersion   string
 
 	SerialPresent  string
 	SerialType     string
@@ -175,6 +176,7 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 
 		SoundPresent: map[bool]string{true: "TRUE", false: "FALSE"}[config.Sound],
 		UsbPresent:   map[bool]string{true: "TRUE", false: "FALSE"}[config.USB],
+		UsbVersion:   config.USBVersion,
 
 		SerialPresent:   "FALSE",
 		ParallelPresent: "FALSE",
@@ -463,9 +465,6 @@ pciBridge7.pciSlotNumber = "24"
 pciBridge7.present = "TRUE"
 pciBridge7.virtualDev = "pcieRootPort"
 
-ehci.present = "TRUE"
-ehci.pciSlotNumber = "34"
-
 vmci0.present = "TRUE"
 vmci0.id = "1861462627"
 vmci0.pciSlotNumber = "35"
@@ -505,9 +504,10 @@ sound.present = "{{ .SoundPresent }}"
 sound.fileName = "-1"
 sound.autodetect = "TRUE"
 
-// USB
-usb.pciSlotNumber = "32"
-usb.present = "{{ .UsbPresent }}"
+// USB Controllers
+{{ if .UsbPresent }}usb.present = "{{ .UsbPresent }}"{{ end }}
+{{ if .UsbPresent }}ehci.present = "{{ .UsbPresent }}"{{ end }}
+{{ if and .UsbPresent (eq .UsbVersion "3.1") }}usb_xhci.present = "{{ .UsbPresent }}"{{ end }}
 
 // Serial
 serial0.present = "{{ .SerialPresent }}"

--- a/docs-partials/builder/vmware/common/HWConfig-not-required.mdx
+++ b/docs-partials/builder/vmware/common/HWConfig-not-required.mdx
@@ -29,11 +29,17 @@
 
 - `sound` (bool) - Enable virtual sound card device. Defaults to `false`.
 
-- `usb` (bool) - Enable USB 2.0 controllers for the virtual machine.
+- `usb` (bool) - Enable USB controller for the virtual machine.
   Defaults to `false`.
   
-  ~> **Note:** To enable USB 3.0 controllers, set a `usb_xhci.present`
-  key to `true` in the `vmx_data` option.
+  ~> **Note:** Automatically enabled on Apple Silicon-based systems to
+  ensure plugin functionality.
+
+- `usb_version` (string) - USB version to use when USB is enabled. Defaults to "2.0".
+  Allowed values are "2.0" and "3.1".
+  
+  ~> **Note:** Automatically set on Apple Silicon-based systems to ensure
+  plugin functionality.
 
 - `serial` (string) - Add a serial port to the virtual machine. Use a format of
   `Type:option1,option2,...`. Allowed values for the field `Type` include:

--- a/example/README.md
+++ b/example/README.md
@@ -5,10 +5,10 @@ desktop hypervisors, VMware Fusion Pro and VMware Workstation Pro.
 
 ## Directory Structure
 
-The source files are spread across multiple files: 
+The source files are spread across multiple files:
 
- - `source.pkr.hcl` contains the source block definition for the machine image. 
- - `variables.pkr.hcl` contains a set of defined variables needed for building the machine image. 
+ - `source.pkr.hcl` contains the source block definition for the machine image.
+ - `variables.pkr.hcl` contains a set of defined variables needed for building the machine image.
  - `build.pkr.hcl` is the main entry point to build the machine image defined in `source.pkr.hcl`.
  - `pkrvars/` contains a set of variable definition files (`*.pkrvars.hcl`) partitioned by `guest_os/product-version`.
 
@@ -26,21 +26,15 @@ packer build -var-file=pkrvars/debian/fusion-arm64.pkrvars.hcl .
   > **Note**
   >
   > VMware Fusion Pro on Apple Silicon does not support the `lsilogic` adapter type and requires additional
-  > `vmx_data ` configurations to support the build. 
-  > 
+  > `vmx_data ` configurations to support the build.
+  >
   > Below are the adapter types and addition configuration options required for VMware Fusion Pro 13 on Apple Silicon:
-  > 
+  >
   > ```hcl
   > cdrom_adapter_type   = "sata"
   > disk_adapter_type    = "nvme"
-  > 
-  > vmx_data = {
-  >   "svga.autodetect"  = true
-  >   "usb_xhci.present" = true
-  > }
-  > 
-  > Please refer to the exanple `fusion-arm64.pkrvars.hcl` for complete details. 
-
+  >
+  > Please refer to the example `fusion-arm64.pkrvars.hcl` for complete details.
 
 **Intel-based Macs (`amd64`/`x86_64`)**
 

--- a/example/pkrvars/debian/fusion-amd64.pkrvars.hcl
+++ b/example/pkrvars/debian/fusion-amd64.pkrvars.hcl
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MPL-2.0
 
 network_adapter_type = "e1000"
-iso_url              = "https://mirrors.ocf.berkeley.edu/debian-cd/13.0.0/amd64/iso-cd/debian-13.0.0-amd64-netinst.iso"
-iso_checksum         = "file:https://mirrors.ocf.berkeley.edu/debian-cd/13.0.0/amd64/iso-cd/SHA256SUMS"
+iso_url              = "https://mirrors.ocf.berkeley.edu/debian-cd/13.1.0/amd64/iso-cd/debian-13.1.0-amd64-netinst.iso"
+iso_checksum         = "file:https://mirrors.ocf.berkeley.edu/debian-cd/13.1.0/amd64/iso-cd/SHA256SUMS"
 data_directory       = "data/debian"
 guest_os_type        = "debian-64"
 boot_command         = ["<wait><esc><wait>auto preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg netcfg/get_hostname={{ .Name }}<enter>"]

--- a/example/pkrvars/debian/fusion-arm64.pkrvars.hcl
+++ b/example/pkrvars/debian/fusion-arm64.pkrvars.hcl
@@ -4,13 +4,10 @@
 cdrom_adapter_type   = "sata"
 disk_adapter_type    = "sata"
 network_adapter_type = "e1000e"
-iso_url              = "https://mirrors.ocf.berkeley.edu/debian-cd/13.0.0/arm64/iso-cd/debian-13.0.0-arm64-netinst.iso"
-iso_checksum         = "file:https://mirrors.ocf.berkeley.edu/debian-cd/13.0.0/arm64/iso-cd/SHA256SUMS"
+iso_url              = "https://mirrors.ocf.berkeley.edu/debian-cd/13.1.0/arm64/iso-cd/debian-13.1.0-arm64-netinst.iso"
+iso_checksum         = "file:https://mirrors.ocf.berkeley.edu/debian-cd/13.1.0/arm64/iso-cd/SHA256SUMS"
 data_directory       = "data/debian"
 guest_os_type        = "arm-debian-64"
 boot_command         = ["<wait><up>e<wait><down><down><down><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><right><wait>install <wait> preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg <wait>debian-installer=en_US.UTF-8 <wait>auto <wait>locale=en_US.UTF-8 <wait>kbd-chooser/method=us <wait>keyboard-configuration/xkb-keymap=us <wait>netcfg/get_hostname={{ .Name }} <wait>netcfg/get_domain={{ .Name }} <wait>fb=false <wait>debconf/frontend=noninteractive <wait>console-setup/ask_detect=false <wait>console-keymaps-at/keymap=us <wait>grub-installer/bootdev=/dev/sda <wait><f10><wait>"]
 vm_name              = "debian-arm64"
-vmx_data = {
-  "usb_xhci.present" = "TRUE"
-  "svga.autodetect"  = "TRUE"
-}
+vmx_data             = {}

--- a/example/pkrvars/debian/workstation-amd64.pkrvars.hcl
+++ b/example/pkrvars/debian/workstation-amd64.pkrvars.hcl
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MPL-2.0
 
 network_adapter_type = "e1000"
-iso_url              = "https://mirrors.ocf.berkeley.edu/debian-cd/13.0.0/amd64/iso-cd/debian-13.0.0-amd64-netinst.iso"
-iso_checksum         = "file:https://mirrors.ocf.berkeley.edu/debian-cd/13.0.0/amd64/iso-cd/SHA256SUMS"
+iso_url              = "https://mirrors.ocf.berkeley.edu/debian-cd/13.1.0/amd64/iso-cd/debian-13.1.0-amd64-netinst.iso"
+iso_checksum         = "file:https://mirrors.ocf.berkeley.edu/debian-cd/13.1.0/amd64/iso-cd/SHA256SUMS"
 data_directory       = "data/debian"
 guest_os_type        = "debian-64"
 boot_command         = ["<wait><esc><wait>auto preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg netcfg/get_hostname={{ .Name }}<enter>"]


### PR DESCRIPTION
### Description

> [!CAUTION]
> This is a **breaking change** and will be shipped in v2. 

Introduces support for configurable USB controller versions in virtual machine builds, with improved handling for Apple Silicon systems. The changes allow users to specify the USB version ("2.0" or "3.1") via a new `usb_version` option, and ensure automatic USB configuration for plugin compatibility on Apple Silicon. Extensive validation and tests have been added to ensure correct behavior across platforms.

**USB Controller Configuration Enhancements:**

* Added a new `usb_version` option to allow selection between USB 2.0 and USB 3.1 controllers when USB is enabled, with validation for allowed values. [[1]](diffhunk://#diff-5abb38f2f9b2a09eef799c250f9db4cd18a48b5a84cb4a4f458e427d4798bdbeL48-R60) [[2]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3R209-R214) [[3]](diffhunk://#diff-71f7e9a9cf98e960982f63d0beca44f4d68d4b868f178419727bb2a496f8f33bR56) [[4]](diffhunk://#diff-71f7e9a9cf98e960982f63d0beca44f4d68d4b868f178419727bb2a496f8f33bR197)
* Improved handling for Apple Silicon (`darwin/arm64`): USB is automatically enabled and set to version 2.0 if not explicitly configured, ensuring plugin functionality. [[1]](diffhunk://#diff-5abb38f2f9b2a09eef799c250f9db4cd18a48b5a84cb4a4f458e427d4798bdbeL141-R169) [[2]](diffhunk://#diff-36d6bf8a75354631b8d2fa872940a3648bacbb2bef93f578bd81a8dc02013b1fR39-R53)

**VMX Template and Build Logic:**

* Updated the VMX template and build logic to conditionally include USB controller configuration based on `usb` and `usb_version` values, supporting both USB 2.0 and 3.1. [[1]](diffhunk://#diff-69b312abca15e1a6e28abae7463a3d2ce360e110d54a0b2cf9d37bf3429f7e3aR43) [[2]](diffhunk://#diff-69b312abca15e1a6e28abae7463a3d2ce360e110d54a0b2cf9d37bf3429f7e3aR179) [[3]](diffhunk://#diff-69b312abca15e1a6e28abae7463a3d2ce360e110d54a0b2cf9d37bf3429f7e3aL508-R510)

**Validation and Testing:**

* Added comprehensive unit tests to verify USB configuration, version selection, defaulting, and error handling for invalid settings. [[1]](diffhunk://#diff-36d6bf8a75354631b8d2fa872940a3648bacbb2bef93f578bd81a8dc02013b1fR343-R476) [[2]](diffhunk://#diff-ed907ac5ab32344938b445b3a1aae1db51729baa23eba24b0bb35aa833699cddR380-R591)

**Documentation Updates:**

* Updated documentation to reflect new USB configuration options and platform-specific behavior, including changes in `.web-docs/components/builder/iso/README.md` and `docs-partials/builder/vmware/common/HWConfig-not-required.mdx`. [[1]](diffhunk://#diff-65e329d9f6a8d0aecefed129bf5c4d7f389b1b5875468ccd963c6fbade3b50d0L137-R147) [[2]](diffhunk://#diff-385cd576c6630a4d1e75fc453a45cb7db87745eb569e59f5bb5ee452cb1cb104L32-R42)

**Example and Cleanup:**

* Removed legacy manual USB configuration instructions from the example README, as USB controllers are now handled automatically and via the new options.

### Resolved Issues

- Adds USB 3.1 support to the plugin without the need to use `vmx_data`.
- Automatically enables USB for VMware Fusion on Apple Silicon-based systems as it's required on `arm64`.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
