### PR TITLE
feat: attach tools iso

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -275,21 +275,38 @@ JSON Example:
 
 <!-- Code generated from the comments of the ToolsConfig struct in builder/vmware/common/tools_config.go; DO NOT EDIT MANUALLY -->
 
-- `tools_upload_flavor` (string) - The flavor of VMware Tools to upload into the virtual machine based on
-  the guest operating system. Allowed values are `darwin` (macOS), `linux`,
-  and `windows`. Default is empty and no version will be uploaded.
+- `tools_mode` (string) - The mode for providing VMware Tools to the virtual machine. Must be
+  explicitly specified when using any tools configuration. Allowed values are:
+  - `upload`: Uploads VMware Tools ISO to the virtual machine during the build.
+    Requires either `tools_upload_flavor` or `tools_source_path` to be specified.
+  - `attach`: Attaches the VMware Tools ISO to the virtual machine as a CD-ROM
+    device during the build and removes the device upon build completion.
+    Requires `tools_source_path` to be specified.
+  - `disable`: No VMware Tools ISO is provided to the virtual machine.
+    Any other tools configuration fields are ignored.
 
-- `tools_upload_path` (string) - The path in the VM to upload the VMware tools. This only takes effect if
-  `tools_upload_flavor` is non-empty. This is a [configuration
-  template](/packer/docs/templates/legacy_json_templates/engine) that has a
-  single valid variable: `Flavor`, which will be the value of
-  `tools_upload_flavor`. By default, the upload path is set to
-  `{{.Flavor}}.iso`.
-
-- `tools_source_path` (string) - The local path on your machine to the VMware Tools ISO file.
+- `tools_source_path` (string) - The absolute local path on your machine to the VMware Tools ISO file.
+  Can be used with `tools_mode` set to `attach` or `upload`. When used with
+  `upload` mode, cannot be used together with `tools_upload_flavor`.
   
-  ~> **Note:** If not set, but the `tools_upload_flavor` is set, the plugin
-  will load the VMware Tools from the product installation directory.
+  Must be a path accessible during the build (e.g., "/path/to/vmware-tools.iso".)
+
+- `tools_upload_flavor` (string) - The flavor of VMware Tools to upload into the virtual machine based on the
+  guest operating system. Can only be used when `tools_mode` is set to
+  `upload`. Cannot be used together with `tools_source_path`. Allowed
+  values include: `darwin` (macOS), `linux`, and `windows`.
+  
+  The plugin will load the VMware Tools ISO from the desktop hypervisor's
+  default installation directory based on the specified flavor, if available.
+
+- `tools_upload_path` (string) - The absolute path in the virtual machine guest operating system where the
+  VMware Tools ISO will be uploaded. Only used when `tools_mode` is set to
+  `upload`. This is a [configuration template](/packer/docs/templates/legacy_json_templates/engine)
+  that has a single valid variable: `Flavor`, which will be the value of
+  `tools_upload_flavor`. Defaults to `{{.Flavor}}.iso` when
+  `tools_upload_flavor` is specified.
+  
+  Must be an absolute path in the guest operating system (e.g., "/tmp/vmware-tools.iso").
 
 <!-- End of code generated from the comments of the ToolsConfig struct in builder/vmware/common/tools_config.go; -->
 

--- a/.web-docs/components/builder/vmx/README.md
+++ b/.web-docs/components/builder/vmx/README.md
@@ -141,21 +141,38 @@ JSON Example:
 
 <!-- Code generated from the comments of the ToolsConfig struct in builder/vmware/common/tools_config.go; DO NOT EDIT MANUALLY -->
 
-- `tools_upload_flavor` (string) - The flavor of VMware Tools to upload into the virtual machine based on
-  the guest operating system. Allowed values are `darwin` (macOS), `linux`,
-  and `windows`. Default is empty and no version will be uploaded.
+- `tools_mode` (string) - The mode for providing VMware Tools to the virtual machine. Must be
+  explicitly specified when using any tools configuration. Allowed values are:
+  - `upload`: Uploads VMware Tools ISO to the virtual machine during the build.
+    Requires either `tools_upload_flavor` or `tools_source_path` to be specified.
+  - `attach`: Attaches the VMware Tools ISO to the virtual machine as a CD-ROM
+    device during the build and removes the device upon build completion.
+    Requires `tools_source_path` to be specified.
+  - `disable`: No VMware Tools ISO is provided to the virtual machine.
+    Any other tools configuration fields are ignored.
 
-- `tools_upload_path` (string) - The path in the VM to upload the VMware tools. This only takes effect if
-  `tools_upload_flavor` is non-empty. This is a [configuration
-  template](/packer/docs/templates/legacy_json_templates/engine) that has a
-  single valid variable: `Flavor`, which will be the value of
-  `tools_upload_flavor`. By default, the upload path is set to
-  `{{.Flavor}}.iso`.
-
-- `tools_source_path` (string) - The local path on your machine to the VMware Tools ISO file.
+- `tools_source_path` (string) - The absolute local path on your machine to the VMware Tools ISO file.
+  Can be used with `tools_mode` set to `attach` or `upload`. When used with
+  `upload` mode, cannot be used together with `tools_upload_flavor`.
   
-  ~> **Note:** If not set, but the `tools_upload_flavor` is set, the plugin
-  will load the VMware Tools from the product installation directory.
+  Must be a path accessible during the build (e.g., "/path/to/vmware-tools.iso".)
+
+- `tools_upload_flavor` (string) - The flavor of VMware Tools to upload into the virtual machine based on the
+  guest operating system. Can only be used when `tools_mode` is set to
+  `upload`. Cannot be used together with `tools_source_path`. Allowed
+  values include: `darwin` (macOS), `linux`, and `windows`.
+  
+  The plugin will load the VMware Tools ISO from the desktop hypervisor's
+  default installation directory based on the specified flavor, if available.
+
+- `tools_upload_path` (string) - The absolute path in the virtual machine guest operating system where the
+  VMware Tools ISO will be uploaded. Only used when `tools_mode` is set to
+  `upload`. This is a [configuration template](/packer/docs/templates/legacy_json_templates/engine)
+  that has a single valid variable: `Flavor`, which will be the value of
+  `tools_upload_flavor`. Defaults to `{{.Flavor}}.iso` when
+  `tools_upload_flavor` is specified.
+  
+  Must be an absolute path in the guest operating system (e.g., "/tmp/vmware-tools.iso").
 
 <!-- End of code generated from the comments of the ToolsConfig struct in builder/vmware/common/tools_config.go; -->
 

--- a/builder/vmware/common/cdrom_utils.go
+++ b/builder/vmware/common/cdrom_utils.go
@@ -1,0 +1,152 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// FindNextAvailableCDROMSlot locates the next available CD-ROM device slot for
+// the specified adapter type.
+func FindNextAvailableCDROMSlot(vmxData map[string]string, adapterType string) (string, error) {
+	if adapterType == "" {
+		return "", fmt.Errorf("adapter type cannot be empty")
+	}
+
+	adapterType = strings.ToLower(adapterType)
+
+	validAdapters := []string{"ide", "sata", "scsi"}
+	isValid := false
+	for _, valid := range validAdapters {
+		if adapterType == valid {
+			isValid = true
+			break
+		}
+	}
+	if !isValid {
+		return "", fmt.Errorf("invalid adapter type: %s; must be one of %v", adapterType, validAdapters)
+	}
+
+	devicePattern := regexp.MustCompile(fmt.Sprintf(`^%s(\d+):(\d+)\.present$`, adapterType))
+	usedSlots := make(map[string]map[int]bool) // bus -> slot -> used
+
+	for key := range vmxData {
+		if matches := devicePattern.FindStringSubmatch(key); matches != nil {
+			bus := matches[1]
+			slot, err := strconv.Atoi(matches[2])
+			if err != nil {
+				continue
+			}
+
+			if usedSlots[bus] == nil {
+				usedSlots[bus] = make(map[int]bool)
+			}
+			usedSlots[bus][slot] = true
+		}
+	}
+
+	// Find the next available slot.
+	for busNum := 0; busNum < 4; busNum++ { // VMware supports up to 4 buses for most adapter types
+		busStr := strconv.Itoa(busNum)
+		busSlots := usedSlots[busStr]
+
+		// Check slots 0-15 (or 0-6,8-15 for SCSI to skip reserved slot 7).
+		maxSlots := 16
+		if adapterType == "ide" {
+			maxSlots = 2 // IDE typically supports only 2 devices per bus.
+		}
+
+		for slot := 0; slot < maxSlots; slot++ {
+			// Skip reserved slot 7 for SCSI adapters.
+			if adapterType == "scsi" && slot == 7 {
+				continue
+			}
+
+			if busSlots == nil || !busSlots[slot] {
+				return fmt.Sprintf("%s%d:%d", adapterType, busNum, slot), nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no available CD-ROM slots found for adapter type %s", adapterType)
+}
+
+// AttachCDROMDevice adds CD-ROM device entries to VMX data for the specified
+// device path and ISO file.
+func AttachCDROMDevice(vmxData map[string]string, devicePath, isoPath, adapterType string) error {
+	if vmxData == nil {
+		return fmt.Errorf("vmxData cannot be nil")
+	}
+	if devicePath == "" {
+		return fmt.Errorf("devicePath cannot be empty")
+	}
+	if isoPath == "" {
+		return fmt.Errorf("isoPath cannot be empty")
+	}
+	if adapterType == "" {
+		return fmt.Errorf("adapterType cannot be empty")
+	}
+
+	adapterType = strings.ToLower(adapterType)
+	devicePattern := regexp.MustCompile(`^(ide|sata|scsi)(\d+):(\d+)$`)
+	matches := devicePattern.FindStringSubmatch(devicePath)
+	if matches == nil {
+		return fmt.Errorf("invalid device path format: %s; expected format like 'ide0:1'", devicePath)
+	}
+
+	pathAdapterType := matches[1]
+	busNum := matches[2]
+
+	if pathAdapterType != adapterType {
+		return fmt.Errorf("device path adapter type %s does not match specified adapter type %s", pathAdapterType, adapterType)
+	}
+
+	presentKey := fmt.Sprintf("%s.present", devicePath)
+	if existing, exists := vmxData[presentKey]; exists && strings.ToLower(existing) == "true" {
+		return fmt.Errorf("device %s is already in use", devicePath)
+	}
+
+	adapterKey := fmt.Sprintf("%s%s.present", adapterType, busNum)
+	vmxData[adapterKey] = "TRUE"
+
+	vmxData[fmt.Sprintf("%s.present", devicePath)] = "TRUE"
+	vmxData[fmt.Sprintf("%s.filename", devicePath)] = isoPath
+	vmxData[fmt.Sprintf("%s.devicetype", devicePath)] = "cdrom-image"
+
+	return nil
+}
+
+// DetachCDROMDevice removes CD-ROM device entries from VMX data for the
+// specified device path.
+func DetachCDROMDevice(vmxData map[string]string, devicePath string) error {
+	if vmxData == nil {
+		return fmt.Errorf("vmxData cannot be nil")
+	}
+	if devicePath == "" {
+		return fmt.Errorf("devicePath cannot be empty")
+	}
+
+	devicePattern := regexp.MustCompile(`^(ide|sata|scsi)(\d+):(\d+)$`)
+	if !devicePattern.MatchString(devicePath) {
+		return fmt.Errorf("invalid device path format: %s; expected format like 'ide0:1'", devicePath)
+	}
+
+	devicePrefix := devicePath + "."
+	keysToDelete := make([]string, 0)
+
+	for key := range vmxData {
+		if strings.HasPrefix(key, devicePrefix) {
+			keysToDelete = append(keysToDelete, key)
+		}
+	}
+
+	for _, key := range keysToDelete {
+		delete(vmxData, key)
+	}
+
+	return nil
+}

--- a/builder/vmware/common/cdrom_utils_test.go
+++ b/builder/vmware/common/cdrom_utils_test.go
@@ -1,0 +1,446 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"testing"
+)
+
+func TestFindNextAvailableCDROMSlot(t *testing.T) {
+	tests := []struct {
+		name        string
+		vmxData     map[string]string
+		adapterType string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:        "empty VMX data - IDE adapter",
+			vmxData:     map[string]string{},
+			adapterType: "ide",
+			expected:    "ide0:0",
+			expectError: false,
+		},
+		{
+			name:        "empty VMX data - SATA adapter",
+			vmxData:     map[string]string{},
+			adapterType: "sata",
+			expected:    "sata0:0",
+			expectError: false,
+		},
+		{
+			name:        "empty VMX data - SCSI adapter",
+			vmxData:     map[string]string{},
+			adapterType: "scsi",
+			expected:    "scsi0:0",
+			expectError: false,
+		},
+		{
+			name: "IDE slot 0 occupied - should return slot 1",
+			vmxData: map[string]string{
+				"ide0:0.present": "TRUE",
+			},
+			adapterType: "ide",
+			expected:    "ide0:1",
+			expectError: false,
+		},
+		{
+			name: "SCSI slots 0-6 occupied - should skip slot 7 and return slot 8",
+			vmxData: map[string]string{
+				"scsi0:0.present": "TRUE",
+				"scsi0:1.present": "TRUE",
+				"scsi0:2.present": "TRUE",
+				"scsi0:3.present": "TRUE",
+				"scsi0:4.present": "TRUE",
+				"scsi0:5.present": "TRUE",
+				"scsi0:6.present": "TRUE",
+			},
+			adapterType: "scsi",
+			expected:    "scsi0:8",
+			expectError: false,
+		},
+		{
+			name: "multiple buses - should use next bus when current is full",
+			vmxData: map[string]string{
+				"ide0:0.present": "TRUE",
+				"ide0:1.present": "TRUE",
+			},
+			adapterType: "ide",
+			expected:    "ide1:0",
+			expectError: false,
+		},
+		{
+			name: "mixed adapter types - should only consider specified type",
+			vmxData: map[string]string{
+				"ide0:0.present":  "TRUE",
+				"sata0:0.present": "TRUE",
+				"scsi0:0.present": "TRUE",
+			},
+			adapterType: "ide",
+			expected:    "ide0:1",
+			expectError: false,
+		},
+		{
+			name:        "empty adapter type - should return error",
+			vmxData:     map[string]string{},
+			adapterType: "",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "invalid adapter type - should return error",
+			vmxData:     map[string]string{},
+			adapterType: "invalid",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "case insensitive adapter type",
+			vmxData:     map[string]string{},
+			adapterType: "IDE",
+			expected:    "ide0:0",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := FindNextAvailableCDROMSlot(tt.vmxData, tt.adapterType)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if result != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestAttachCDROMDevice(t *testing.T) {
+	tests := []struct {
+		name         string
+		vmxData      map[string]string
+		devicePath   string
+		isoPath      string
+		adapterType  string
+		expectError  bool
+		expectedKeys map[string]string
+	}{
+		{
+			name:        "successful IDE attachment",
+			vmxData:     map[string]string{},
+			devicePath:  "ide0:1",
+			isoPath:     "/path/to/tools.iso",
+			adapterType: "ide",
+			expectError: false,
+			expectedKeys: map[string]string{
+				"ide0.present":      "TRUE",
+				"ide0:1.present":    "TRUE",
+				"ide0:1.filename":   "/path/to/tools.iso",
+				"ide0:1.devicetype": "cdrom-image",
+			},
+		},
+		{
+			name:        "successful SATA attachment",
+			vmxData:     map[string]string{},
+			devicePath:  "sata0:0",
+			isoPath:     "/path/to/tools.iso",
+			adapterType: "sata",
+			expectError: false,
+			expectedKeys: map[string]string{
+				"sata0.present":      "TRUE",
+				"sata0:0.present":    "TRUE",
+				"sata0:0.filename":   "/path/to/tools.iso",
+				"sata0:0.devicetype": "cdrom-image",
+			},
+		},
+		{
+			name:        "successful SCSI attachment",
+			vmxData:     map[string]string{},
+			devicePath:  "scsi0:8",
+			isoPath:     "/path/to/tools.iso",
+			adapterType: "scsi",
+			expectError: false,
+			expectedKeys: map[string]string{
+				"scsi0.present":      "TRUE",
+				"scsi0:8.present":    "TRUE",
+				"scsi0:8.filename":   "/path/to/tools.iso",
+				"scsi0:8.devicetype": "cdrom-image",
+			},
+		},
+		{
+			name: "device already in use - should return error",
+			vmxData: map[string]string{
+				"ide0:1.present": "TRUE",
+			},
+			devicePath:  "ide0:1",
+			isoPath:     "/path/to/tools.iso",
+			adapterType: "ide",
+			expectError: true,
+		},
+		{
+			name:        "nil vmxData - should return error",
+			vmxData:     nil,
+			devicePath:  "ide0:1",
+			isoPath:     "/path/to/tools.iso",
+			adapterType: "ide",
+			expectError: true,
+		},
+		{
+			name:        "empty devicePath - should return error",
+			vmxData:     map[string]string{},
+			devicePath:  "",
+			isoPath:     "/path/to/tools.iso",
+			adapterType: "ide",
+			expectError: true,
+		},
+		{
+			name:        "empty isoPath - should return error",
+			vmxData:     map[string]string{},
+			devicePath:  "ide0:1",
+			isoPath:     "",
+			adapterType: "ide",
+			expectError: true,
+		},
+		{
+			name:        "empty adapterType - should return error",
+			vmxData:     map[string]string{},
+			devicePath:  "ide0:1",
+			isoPath:     "/path/to/tools.iso",
+			adapterType: "",
+			expectError: true,
+		},
+		{
+			name:        "invalid device path format - should return error",
+			vmxData:     map[string]string{},
+			devicePath:  "invalid",
+			isoPath:     "/path/to/tools.iso",
+			adapterType: "ide",
+			expectError: true,
+		},
+		{
+			name:        "mismatched adapter types - should return error",
+			vmxData:     map[string]string{},
+			devicePath:  "ide0:1",
+			isoPath:     "/path/to/tools.iso",
+			adapterType: "sata",
+			expectError: true,
+		},
+		{
+			name:        "case insensitive adapter type",
+			vmxData:     map[string]string{},
+			devicePath:  "ide0:1",
+			isoPath:     "/path/to/tools.iso",
+			adapterType: "IDE",
+			expectError: false,
+			expectedKeys: map[string]string{
+				"ide0.present":      "TRUE",
+				"ide0:1.present":    "TRUE",
+				"ide0:1.filename":   "/path/to/tools.iso",
+				"ide0:1.devicetype": "cdrom-image",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := AttachCDROMDevice(tt.vmxData, tt.devicePath, tt.isoPath, tt.adapterType)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			// Check that expected keys are present with correct values
+			for key, expectedValue := range tt.expectedKeys {
+				if actualValue, exists := tt.vmxData[key]; !exists {
+					t.Errorf("expected key %s not found in vmxData", key)
+				} else if actualValue != expectedValue {
+					t.Errorf("key %s: expected %s, got %s", key, expectedValue, actualValue)
+				}
+			}
+		})
+	}
+}
+
+func TestDetachCDROMDevice(t *testing.T) {
+	tests := []struct {
+		name           string
+		vmxData        map[string]string
+		devicePath     string
+		expectError    bool
+		expectedRemain map[string]string
+	}{
+		{
+			name: "successful detachment - removes all device keys",
+			vmxData: map[string]string{
+				"ide0.present":      "TRUE",
+				"ide0:1.present":    "TRUE",
+				"ide0:1.filename":   "/path/to/tools.iso",
+				"ide0:1.devicetype": "cdrom-image",
+				"ide0:0.present":    "TRUE", // should remain
+				"sata0:0.present":   "TRUE", // should remain
+			},
+			devicePath:  "ide0:1",
+			expectError: false,
+			expectedRemain: map[string]string{
+				"ide0.present":    "TRUE",
+				"ide0:0.present":  "TRUE",
+				"sata0:0.present": "TRUE",
+			},
+		},
+		{
+			name:           "detach from empty vmxData - should succeed",
+			vmxData:        map[string]string{},
+			devicePath:     "ide0:1",
+			expectError:    false,
+			expectedRemain: map[string]string{},
+		},
+		{
+			name: "detach non-existent device - should succeed",
+			vmxData: map[string]string{
+				"ide0:0.present": "TRUE",
+			},
+			devicePath:  "ide0:1",
+			expectError: false,
+			expectedRemain: map[string]string{
+				"ide0:0.present": "TRUE",
+			},
+		},
+		{
+			name:        "nil vmxData - should return error",
+			vmxData:     nil,
+			devicePath:  "ide0:1",
+			expectError: true,
+		},
+		{
+			name:        "empty devicePath - should return error",
+			vmxData:     map[string]string{},
+			devicePath:  "",
+			expectError: true,
+		},
+		{
+			name:        "invalid device path format - should return error",
+			vmxData:     map[string]string{},
+			devicePath:  "invalid",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := DetachCDROMDevice(tt.vmxData, tt.devicePath)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			// Check that only expected keys remain
+			if len(tt.vmxData) != len(tt.expectedRemain) {
+				t.Errorf("expected %d keys to remain, got %d", len(tt.expectedRemain), len(tt.vmxData))
+			}
+
+			for key, expectedValue := range tt.expectedRemain {
+				if actualValue, exists := tt.vmxData[key]; !exists {
+					t.Errorf("expected key %s not found in vmxData", key)
+				} else if actualValue != expectedValue {
+					t.Errorf("key %s: expected %s, got %s", key, expectedValue, actualValue)
+				}
+			}
+
+			// Check that device-specific keys were removed
+			devicePrefix := tt.devicePath + "."
+			for key := range tt.vmxData {
+				if len(key) > len(devicePrefix) && key[:len(devicePrefix)] == devicePrefix {
+					t.Errorf("device key %s should have been removed", key)
+				}
+			}
+		})
+	}
+}
+
+// TestCDROMUtilsIntegration tests the utilities working together
+func TestCDROMUtilsIntegration(t *testing.T) {
+	vmxData := map[string]string{
+		"ide0:0.present": "TRUE", // existing installation ISO
+	}
+
+	devicePath, err := FindNextAvailableCDROMSlot(vmxData, "ide")
+	if err != nil {
+		t.Fatalf("FindNextAvailableCDROMSlot failed: %v", err)
+	}
+
+	expectedPath := "ide0:1"
+	if devicePath != expectedPath {
+		t.Errorf("expected device path %s, got %s", expectedPath, devicePath)
+	}
+
+	isoPath := "/path/to/vmware-tools.iso"
+	err = AttachCDROMDevice(vmxData, devicePath, isoPath, "ide")
+	if err != nil {
+		t.Fatalf("AttachCDROMDevice failed: %v", err)
+	}
+
+	expectedKeys := map[string]string{
+		"ide0.present":      "TRUE",
+		"ide0:1.present":    "TRUE",
+		"ide0:1.filename":   isoPath,
+		"ide0:1.devicetype": "cdrom-image",
+	}
+
+	for key, expectedValue := range expectedKeys {
+		if actualValue, exists := vmxData[key]; !exists {
+			t.Errorf("expected key %s not found after attachment", key)
+		} else if actualValue != expectedValue {
+			t.Errorf("key %s: expected %s, got %s", key, expectedValue, actualValue)
+		}
+	}
+
+	err = DetachCDROMDevice(vmxData, devicePath)
+	if err != nil {
+		t.Fatalf("DetachCDROMDevice failed: %v", err)
+	}
+
+	expectedRemaining := map[string]string{
+		"ide0.present":   "TRUE",
+		"ide0:0.present": "TRUE",
+	}
+
+	if len(vmxData) != len(expectedRemaining) {
+		t.Errorf("expected %d keys after detachment, got %d", len(expectedRemaining), len(vmxData))
+	}
+
+	for key, expectedValue := range expectedRemaining {
+		if actualValue, exists := vmxData[key]; !exists {
+			t.Errorf("expected key %s not found after detachment", key)
+		} else if actualValue != expectedValue {
+			t.Errorf("key %s: expected %s, got %s", key, expectedValue, actualValue)
+		}
+	}
+}

--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -141,6 +141,11 @@ const (
 	// ExportFormatVmx defines the export format as "vmx" for Virtual Machine eXchange.
 	ExportFormatVmx = "vmx"
 
+	// Tools mode constants
+	toolsModeUpload  = "upload"
+	toolsModeAttach  = "attach"
+	toolsModeDisable = "disable"
+
 	// Tools flavors.
 	toolsFlavorMacOS   = osMacOS
 	toolsFlavorLinux   = osLinux
@@ -210,6 +215,13 @@ var AllowedCdromAdapterTypes = []string{
 var AllowedUsbVersions = []string{
 	UsbVersion20,
 	UsbVersion31,
+}
+
+// The allowed values for the `ToolsMode`.
+var allowedToolsModeValues = []string{
+	toolsModeUpload,
+	toolsModeAttach,
+	toolsModeDisable,
 }
 
 // The allowed values for the `ToolsUploadFlavor`.

--- a/builder/vmware/common/step_attach_tools_cdrom.go
+++ b/builder/vmware/common/step_attach_tools_cdrom.go
@@ -1,0 +1,133 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+// StepAttachToolsCDROM represents a step to attach VMware Tools ISO as a CD-ROM device.
+type StepAttachToolsCDROM struct {
+	ToolsMode         string
+	ToolsSourcePath   string
+	ToolsUploadFlavor string
+	CDROMAdapterType  string
+}
+
+// Run executes the tools CD-ROM attachment step, attaching the VMware Tools ISO as a CD-ROM device.
+func (s *StepAttachToolsCDROM) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	// Skip if tools mode is not 'attach'.
+	if s.ToolsMode != toolsModeAttach {
+		return multistep.ActionContinue
+	}
+
+	ui := state.Get("ui").(packersdk.Ui)
+	driver := state.Get("driver").(Driver)
+
+	// Determine the tools source path.
+	var toolsPath string
+
+	// Check if path is already in state.
+	if toolsSourcePath, ok := state.GetOk("tools_attach_source"); ok && toolsSourcePath != "" {
+		toolsPath = toolsSourcePath.(string)
+	} else {
+		// Resolve path from configuration.
+		toolsPath = s.ToolsSourcePath
+		if toolsPath == "" && s.ToolsUploadFlavor != "" {
+			toolsPath = driver.ToolsIsoPath(s.ToolsUploadFlavor)
+		}
+	}
+
+	// Skip if no tools path is available.
+	if toolsPath == "" {
+		log.Println("[INFO] No tools source path available, skipping tools CD-ROM attachment")
+		return multistep.ActionContinue
+	}
+
+	// Validate that the file exists.
+	if _, err := os.Stat(toolsPath); err != nil {
+		if os.IsNotExist(err) && s.ToolsUploadFlavor != "" {
+			err = fmt.Errorf("unable to locate a VMware Tools ISO for %q in the default path: %s", s.ToolsUploadFlavor, toolsPath)
+		} else {
+			err = fmt.Errorf("error accessing VMware Tools ISO: %s", err)
+		}
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	vmxPath := state.Get("vmx_path").(string)
+	log.Printf("[INFO] Attaching VMware Tools ISO as CD-ROM: %s", toolsPath)
+
+	vmxData, err := ReadVMX(vmxPath)
+	if err != nil {
+		err = fmt.Errorf("error reading VMX file: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	// Determine the CD-ROM adapter type.
+	adapterType := s.CDROMAdapterType
+	if adapterType == "" {
+		adapterType = "ide"
+	}
+
+	// Find the next available slot.
+	devicePath, err := FindNextAvailableCDROMSlot(vmxData, adapterType)
+	if err != nil {
+		err = fmt.Errorf("error finding available CD-ROM slot: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	log.Printf("[INFO] Using CD-ROM device slot: %s", devicePath)
+
+	// Attach the CD-ROM device.
+	err = AttachCDROMDevice(vmxData, devicePath, toolsPath, adapterType)
+	if err != nil {
+		err = fmt.Errorf("error attaching tools CD-ROM device: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	// Write the updated .vmx configuration file.
+	err = WriteVMX(vmxPath, vmxData)
+	if err != nil {
+		err = fmt.Errorf("error writing VMX file: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	// Store the attached device information in state bag for cleanup.
+	state.Put("tools_cdrom_device", devicePath)
+	state.Put("tools_cdrom_adapter", adapterType)
+
+	// Add to temporary devices list for cleanup.
+	tmpBuildDevices, ok := state.GetOk("temporaryDevices")
+	if !ok {
+		tmpBuildDevices = []string{}
+	}
+	devices := tmpBuildDevices.([]string)
+	devices = append(devices, devicePath)
+	state.Put("temporaryDevices", devices)
+
+	ui.Say(fmt.Sprintf("Attached VMware Tools ISO as CD-ROM device: %s", devicePath))
+
+	return multistep.ActionContinue
+}
+
+// Cleanup performs any necessary cleanup after the tools CD-ROM attachment step completes.
+func (s *StepAttachToolsCDROM) Cleanup(state multistep.StateBag) {
+	// No-op
+}

--- a/builder/vmware/common/step_attach_tools_cdrom_test.go
+++ b/builder/vmware/common/step_attach_tools_cdrom_test.go
@@ -1,0 +1,270 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+)
+
+func TestStepAttachToolsCDROM_impl(t *testing.T) {
+	var _ multistep.Step = new(StepAttachToolsCDROM)
+}
+
+func TestStepAttachToolsCDROM_SkipWhenNotAttachMode(t *testing.T) {
+	state := testState(t)
+	step := &StepAttachToolsCDROM{
+		ToolsMode: toolsModeUpload,
+	}
+
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+}
+
+func TestStepAttachToolsCDROM_SkipWhenNoToolsSource(t *testing.T) {
+	state := testState(t)
+	step := &StepAttachToolsCDROM{
+		ToolsMode: toolsModeAttach,
+	}
+
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+}
+
+func TestStepAttachToolsCDROM_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	vmxPath := filepath.Join(tmpDir, "test.vmx")
+
+	vmxContent := `config.version = "8"
+virtualHW.version = "10"
+displayName = "test"
+`
+	err := os.WriteFile(vmxPath, []byte(vmxContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test VMX file: %v", err)
+	}
+
+	toolsIsoPath := filepath.Join(tmpDir, "tools.iso")
+	err = os.WriteFile(toolsIsoPath, []byte("fake iso content"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test tools ISO file: %v", err)
+	}
+
+	state := testState(t)
+	state.Put("vmx_path", vmxPath)
+	state.Put("tools_attach_source", toolsIsoPath)
+
+	step := &StepAttachToolsCDROM{
+		ToolsMode:        toolsModeAttach,
+		CDROMAdapterType: "ide",
+	}
+
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatalf("should NOT have error: %v", state.Get("error"))
+	}
+
+	devicePath, ok := state.GetOk("tools_cdrom_device")
+	if !ok {
+		t.Fatal("should have tools_cdrom_device in state")
+	}
+	if devicePath.(string) != "ide0:0" {
+		t.Fatalf("expected device path 'ide0:0', got '%s'", devicePath.(string))
+	}
+
+	adapterType, ok := state.GetOk("tools_cdrom_adapter")
+	if !ok {
+		t.Fatal("should have tools_cdrom_adapter in state")
+	}
+	if adapterType.(string) != "ide" {
+		t.Fatalf("expected adapter type 'ide', got '%s'", adapterType.(string))
+	}
+
+	tmpDevices := state.Get("temporaryDevices").([]string)
+	found := false
+	for _, device := range tmpDevices {
+		if device == "ide0:0" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("tools CD-ROM device should be added to temporaryDevices")
+	}
+
+	vmxData, err := ReadVMX(vmxPath)
+	if err != nil {
+		t.Fatalf("Failed to read VMX file: %v", err)
+	}
+
+	if vmxData["ide0:0.present"] != "TRUE" {
+		t.Fatal("CD-ROM device should be present")
+	}
+	if vmxData["ide0:0.filename"] != toolsIsoPath {
+		t.Fatalf("expected filename '%s', got '%s'", toolsIsoPath, vmxData["ide0:0.filename"])
+	}
+	if vmxData["ide0:0.devicetype"] != "cdrom-image" {
+		t.Fatalf("expected devicetype 'cdrom-image', got '%s'", vmxData["ide0:0.devicetype"])
+	}
+	if vmxData["ide0.present"] != "TRUE" {
+		t.Fatal("IDE adapter should be present")
+	}
+}
+
+func TestStepAttachToolsCDROM_ConflictResolution(t *testing.T) {
+	tmpDir := t.TempDir()
+	vmxPath := filepath.Join(tmpDir, "test.vmx")
+
+	vmxContent := `config.version = "8"
+virtualHW.version = "10"
+displayName = "test"
+ide0.present = "TRUE"
+ide0:0.present = "TRUE"
+ide0:0.filename = "/path/to/install.iso"
+ide0:0.devicetype = "cdrom-image"
+`
+	err := os.WriteFile(vmxPath, []byte(vmxContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test VMX file: %v", err)
+	}
+
+	// Create a temporary tools ISO file
+	toolsIsoPath := filepath.Join(tmpDir, "tools.iso")
+	err = os.WriteFile(toolsIsoPath, []byte("fake iso content"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test tools ISO file: %v", err)
+	}
+
+	state := testState(t)
+	state.Put("vmx_path", vmxPath)
+	state.Put("tools_attach_source", toolsIsoPath)
+
+	step := &StepAttachToolsCDROM{
+		ToolsMode:        toolsModeAttach,
+		CDROMAdapterType: "ide",
+	}
+
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatalf("should NOT have error: %v", state.Get("error"))
+	}
+
+	devicePath, ok := state.GetOk("tools_cdrom_device")
+	if !ok {
+		t.Fatal("should have tools_cdrom_device in state")
+	}
+	if devicePath.(string) != "ide0:1" {
+		t.Fatalf("expected device path 'ide0:1', got '%s'", devicePath.(string))
+	}
+
+	vmxData, err := ReadVMX(vmxPath)
+	if err != nil {
+		t.Fatalf("Failed to read VMX file: %v", err)
+	}
+
+	if vmxData["ide0:1.present"] != "TRUE" {
+		t.Fatal("Tools CD-ROM device should be present at ide0:1")
+	}
+
+	if vmxData["ide0:1.filename"] != toolsIsoPath {
+		t.Fatalf("expected filename '%s', got '%s'", toolsIsoPath, vmxData["ide0:1.filename"])
+	}
+
+	if vmxData["ide0:0.present"] != "TRUE" {
+		t.Fatal("Original CD-ROM device should still be present")
+	}
+
+	if vmxData["ide0:0.filename"] != "/path/to/install.iso" {
+		t.Fatal("Original CD-ROM device filename should be preserved")
+	}
+}
+
+func TestStepAttachToolsCDROM_DefaultAdapterType(t *testing.T) {
+	tmpDir := t.TempDir()
+	vmxPath := filepath.Join(tmpDir, "test.vmx")
+
+	vmxContent := `config.version = "8"
+virtualHW.version = "10"
+displayName = "test"
+`
+	err := os.WriteFile(vmxPath, []byte(vmxContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test VMX file: %v", err)
+	}
+
+	// Create a temporary tools ISO file
+	toolsIsoPath := filepath.Join(tmpDir, "tools.iso")
+	err = os.WriteFile(toolsIsoPath, []byte("fake iso content"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test tools ISO file: %v", err)
+	}
+
+	state := testState(t)
+	state.Put("vmx_path", vmxPath)
+	state.Put("tools_attach_source", toolsIsoPath)
+
+	step := &StepAttachToolsCDROM{
+		ToolsMode: toolsModeAttach,
+	}
+
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatalf("should NOT have error: %v", state.Get("error"))
+	}
+
+	adapterType, ok := state.GetOk("tools_cdrom_adapter")
+	if !ok {
+		t.Fatal("should have tools_cdrom_adapter in state")
+	}
+
+	if adapterType.(string) != "ide" {
+		t.Fatalf("expected default adapter type 'ide', got '%s'", adapterType.(string))
+	}
+}
+
+func TestStepAttachToolsCDROM_VMXReadError(t *testing.T) {
+	state := testState(t)
+	state.Put("vmx_path", "/nonexistent/path/test.vmx")
+	state.Put("tools_attach_source", "/path/to/tools.iso")
+
+	step := &StepAttachToolsCDROM{
+		ToolsMode:        toolsModeAttach,
+		CDROMAdapterType: "ide",
+	}
+
+	if action := step.Run(context.Background(), state); action != multistep.ActionHalt {
+		t.Fatalf("expected ActionHalt, got: %#v", action)
+	}
+
+	if _, ok := state.GetOk("error"); !ok {
+		t.Fatal("should have error")
+	}
+}
+
+func TestStepAttachToolsCDROM_Cleanup(t *testing.T) {
+	state := testState(t)
+	step := &StepAttachToolsCDROM{}
+
+	// no-op
+	step.Cleanup(state)
+}

--- a/builder/vmware/common/step_clean_vmx_test.go
+++ b/builder/vmware/common/step_clean_vmx_test.go
@@ -219,3 +219,283 @@ ethernet1.bsdname = "en1"
 ethernet1.connectiontype = "nat"
 foo = "bar"
 `
+
+func TestStepCleanVMX_toolsCDROM(t *testing.T) {
+	state := testState(t)
+	step := new(StepCleanVMX)
+
+	vmxPath := testVMXFile(t)
+	defer os.Remove(vmxPath)
+	if err := os.WriteFile(vmxPath, []byte(testVMXToolsCDROM), 0644); err != nil { //nolint:gosec
+		t.Fatalf("err: %s", err)
+	}
+
+	// Set the path to the temporary vmx
+	state.Put("vmx_path", vmxPath)
+
+	// Set the tools CD-ROM device in state bag (simulating StepAttachToolsCDROM)
+	state.Put("tools_cdrom_device", "ide0:1")
+	state.Put("tools_cdrom_adapter", "ide")
+
+	// Add both installation ISO and tools CD-ROM to temporary devices
+	state.Put("temporaryDevices", []string{"ide0:0", "ide0:1"})
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+
+	// Test the resulting data
+	vmxContents, err := os.ReadFile(vmxPath)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	vmxData := ParseVMX(string(vmxContents))
+
+	cases := []struct {
+		Key   string
+		Value string
+	}{
+		// Installation ISO should be converted to cdrom-raw (existing behavior)
+		{"ide0:0.filename", "auto detect"},
+		{"ide0:0.devicetype", "cdrom-raw"},
+		{"ide0:0.clientdevice", "TRUE"},
+		// Tools CD-ROM should be completely removed
+		{"ide0:1.present", "FALSE"},
+		{"ide0:1.filename", ""},
+		{"ide0:1.devicetype", ""},
+		{"ide0:1.clientdevice", ""},
+		// Other VMX entries should be preserved
+		{"foo", "bar"},
+		{"ide0.present", "TRUE"},
+	}
+
+	for _, tc := range cases {
+		if tc.Value == "" {
+			if _, ok := vmxData[tc.Key]; ok {
+				t.Fatalf("should not have key: %s", tc.Key)
+			}
+		} else {
+			if vmxData[tc.Key] != tc.Value {
+				t.Fatalf("bad: %s expected %#v, got %#v", tc.Key, tc.Value, vmxData[tc.Key])
+			}
+		}
+	}
+}
+
+func TestStepCleanVMX_toolsCDROMOnly(t *testing.T) {
+	state := testState(t)
+	step := new(StepCleanVMX)
+
+	vmxPath := testVMXFile(t)
+	defer os.Remove(vmxPath)
+	if err := os.WriteFile(vmxPath, []byte(testVMXToolsCDROMOnly), 0644); err != nil { //nolint:gosec
+		t.Fatalf("err: %s", err)
+	}
+
+	// Set the path to the temporary vmx
+	state.Put("vmx_path", vmxPath)
+
+	// Set the tools CD-ROM device in state bag (simulating StepAttachToolsCDROM)
+	state.Put("tools_cdrom_device", "sata0:0")
+	state.Put("tools_cdrom_adapter", "sata")
+
+	// Add only tools CD-ROM to temporary devices
+	state.Put("temporaryDevices", []string{"sata0:0"})
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+
+	// Test the resulting data
+	vmxContents, err := os.ReadFile(vmxPath)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	vmxData := ParseVMX(string(vmxContents))
+
+	cases := []struct {
+		Key   string
+		Value string
+	}{
+		// Tools CD-ROM should be completely removed
+		{"sata0:0.present", "FALSE"},
+		{"sata0:0.filename", ""},
+		{"sata0:0.devicetype", ""},
+		// Other VMX entries should be preserved
+		{"foo", "bar"},
+	}
+
+	for _, tc := range cases {
+		if tc.Value == "" {
+			if _, ok := vmxData[tc.Key]; ok {
+				t.Fatalf("should not have key: %s", tc.Key)
+			}
+		} else {
+			if vmxData[tc.Key] != tc.Value {
+				t.Fatalf("bad: %s expected %#v, got %#v", tc.Key, tc.Value, vmxData[tc.Key])
+			}
+		}
+	}
+}
+
+func TestStepCleanVMX_noToolsCDROM(t *testing.T) {
+	state := testState(t)
+	step := new(StepCleanVMX)
+
+	vmxPath := testVMXFile(t)
+	defer os.Remove(vmxPath)
+	if err := os.WriteFile(vmxPath, []byte(testVMXISOPath), 0644); err != nil { //nolint:gosec
+		t.Fatalf("err: %s", err)
+	}
+
+	// Set the path to the temporary vmx
+	state.Put("vmx_path", vmxPath)
+
+	// No tools CD-ROM device in state bag
+	// Add only installation ISO to temporary devices
+	state.Put("temporaryDevices", []string{"ide0:0"})
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+
+	// Test the resulting data
+	vmxContents, err := os.ReadFile(vmxPath)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	vmxData := ParseVMX(string(vmxContents))
+
+	cases := []struct {
+		Key   string
+		Value string
+	}{
+		// Installation ISO should be converted to cdrom-raw (existing behavior)
+		{"ide0:0.filename", "auto detect"},
+		{"ide0:0.devicetype", "cdrom-raw"},
+		// Other entries should be preserved
+		{"ide0:1.filename", "bar"},
+		{"foo", "bar"},
+	}
+
+	for _, tc := range cases {
+		if vmxData[tc.Key] != tc.Value {
+			t.Fatalf("bad: %s expected %#v, got %#v", tc.Key, tc.Value, vmxData[tc.Key])
+		}
+	}
+}
+
+func TestStepCleanVMX_preserveUserCDROM(t *testing.T) {
+	state := testState(t)
+	step := new(StepCleanVMX)
+
+	vmxPath := testVMXFile(t)
+	defer os.Remove(vmxPath)
+	if err := os.WriteFile(vmxPath, []byte(testVMXMultipleCDROM), 0644); err != nil { //nolint:gosec
+		t.Fatalf("err: %s", err)
+	}
+
+	// Set the path to the temporary vmx
+	state.Put("vmx_path", vmxPath)
+
+	// Set the tools CD-ROM device in state bag (simulating StepAttachToolsCDROM)
+	state.Put("tools_cdrom_device", "ide0:1")
+	state.Put("tools_cdrom_adapter", "ide")
+
+	// Add installation ISO and tools CD-ROM to temporary devices
+	// Note: ide1:0 is a user-defined CD-ROM that should be preserved
+	state.Put("temporaryDevices", []string{"ide0:0", "ide0:1"})
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+
+	// Test the resulting data
+	vmxContents, err := os.ReadFile(vmxPath)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	vmxData := ParseVMX(string(vmxContents))
+
+	cases := []struct {
+		Key   string
+		Value string
+	}{
+		// Installation ISO should be converted to cdrom-raw (existing behavior)
+		{"ide0:0.filename", "auto detect"},
+		{"ide0:0.devicetype", "cdrom-raw"},
+		{"ide0:0.clientdevice", "TRUE"},
+		// Tools CD-ROM should be completely removed
+		{"ide0:1.present", "FALSE"},
+		{"ide0:1.filename", ""},
+		{"ide0:1.devicetype", ""},
+		// User-defined CD-ROM should be preserved unchanged
+		{"ide1:0.filename", "user-defined.iso"},
+		{"ide1:0.devicetype", "cdrom-image"},
+		{"ide1:0.present", "TRUE"},
+		// Other VMX entries should be preserved
+		{"foo", "bar"},
+	}
+
+	for _, tc := range cases {
+		if tc.Value == "" {
+			if _, ok := vmxData[tc.Key]; ok {
+				t.Fatalf("should not have key: %s", tc.Key)
+			}
+		} else {
+			if vmxData[tc.Key] != tc.Value {
+				t.Fatalf("bad: %s expected %#v, got %#v", tc.Key, tc.Value, vmxData[tc.Key])
+			}
+		}
+	}
+}
+
+const testVMXToolsCDROM = `
+ide0.present = "TRUE"
+ide0:0.devicetype = "cdrom-image"
+ide0:0.filename = "install.iso"
+ide0:0.present = "TRUE"
+ide0:1.devicetype = "cdrom-image"
+ide0:1.filename = "/path/to/vmware-tools.iso"
+ide0:1.present = "TRUE"
+foo = "bar"
+`
+
+const testVMXToolsCDROMOnly = `
+sata0.present = "TRUE"
+sata0:0.devicetype = "cdrom-image"
+sata0:0.filename = "/path/to/vmware-tools.iso"
+sata0:0.present = "TRUE"
+foo = "bar"
+`
+
+const testVMXMultipleCDROM = `
+ide0.present = "TRUE"
+ide0:0.devicetype = "cdrom-image"
+ide0:0.filename = "install.iso"
+ide0:0.present = "TRUE"
+ide0:1.devicetype = "cdrom-image"
+ide0:1.filename = "/path/to/vmware-tools.iso"
+ide0:1.present = "TRUE"
+ide1.present = "TRUE"
+ide1:0.devicetype = "cdrom-image"
+ide1:0.filename = "user-defined.iso"
+ide1:0.present = "TRUE"
+foo = "bar"
+`

--- a/builder/vmware/common/step_prepare_tools.go
+++ b/builder/vmware/common/step_prepare_tools.go
@@ -12,31 +12,57 @@ import (
 )
 
 type StepPrepareTools struct {
+	ToolsMode         string
 	ToolsUploadFlavor string
 	ToolsSourcePath   string
 }
 
-// Run executes the tools preparation step, locating and validating VMware Tools for upload.
+// Run executes the tools preparation step, locating and validating VMware Tools for both upload and attach modes.
 func (c *StepPrepareTools) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	driver := state.Get("driver").(Driver)
 
-	if c.ToolsUploadFlavor == "" && c.ToolsSourcePath == "" {
+	// Skip if tools is disabled.
+	if c.ToolsMode == toolsModeDisable {
 		return multistep.ActionContinue
 	}
 
+	// Skip if no tools configuration is provided.
+	if c.ToolsUploadFlavor == "" && c.ToolsSourcePath == "" && c.ToolsMode == "" {
+		return multistep.ActionContinue
+	}
+
+	// Determine the tools source path.
 	path := c.ToolsSourcePath
-	if path == "" {
+	if path == "" && c.ToolsUploadFlavor != "" {
 		path = driver.ToolsIsoPath(c.ToolsUploadFlavor)
 	}
 
-	if _, err := os.Stat(path); err != nil {
-		state.Put("error", fmt.Errorf("error finding vmware tools for %q: %s", c.ToolsUploadFlavor, err))
-		return multistep.ActionHalt
+	// Validate that the ISO file exists.
+	if path != "" {
+		if _, err := os.Stat(path); err != nil {
+			if os.IsNotExist(err) && c.ToolsUploadFlavor != "" {
+				state.Put("error", fmt.Errorf("unable to locate a VMware Tools ISO for %q in the default path: %s", c.ToolsUploadFlavor, path))
+			} else {
+				state.Put("error", fmt.Errorf("error accessing VMware Tools ISO: %s", err))
+			}
+			return multistep.ActionHalt
+		}
 	}
 
-	state.Put("tools_upload_source", path)
+	// Store the tools source path in state for both upload and attach modes.
+	if path != "" {
+		if c.ToolsMode == toolsModeAttach {
+			state.Put("tools_attach_source", path)
+		} else {
+			// Default to upload mode for backward compatibility.
+			state.Put("tools_upload_source", path)
+		}
+	}
+
 	return multistep.ActionContinue
 }
 
 // Cleanup performs any necessary cleanup after the tools preparation step completes.
-func (c *StepPrepareTools) Cleanup(multistep.StateBag) {}
+func (c *StepPrepareTools) Cleanup(multistep.StateBag) {
+	// No-op.
+}

--- a/builder/vmware/common/step_prepare_tools_test.go
+++ b/builder/vmware/common/step_prepare_tools_test.go
@@ -25,6 +25,7 @@ func TestStepPrepareTools(t *testing.T) {
 
 	state := testState(t)
 	step := &StepPrepareTools{
+		ToolsMode:         toolsModeUpload,
 		ToolsUploadFlavor: "foo",
 	}
 
@@ -62,6 +63,7 @@ func TestStepPrepareTools(t *testing.T) {
 func TestStepPrepareTools_nonExist(t *testing.T) {
 	state := testState(t)
 	step := &StepPrepareTools{
+		ToolsMode:         toolsModeUpload,
 		ToolsUploadFlavor: "foo",
 	}
 
@@ -95,6 +97,7 @@ func TestStepPrepareTools_nonExist(t *testing.T) {
 func TestStepPrepareTools_SourcePath(t *testing.T) {
 	state := testState(t)
 	step := &StepPrepareTools{
+		ToolsMode:       toolsModeUpload,
 		ToolsSourcePath: "/path/to/tool.iso",
 	}
 
@@ -125,6 +128,7 @@ func TestStepPrepareTools_SourcePath(t *testing.T) {
 func TestStepPrepareTools_SourcePath_exists(t *testing.T) {
 	state := testState(t)
 	step := &StepPrepareTools{
+		ToolsMode:       toolsModeUpload,
 		ToolsSourcePath: "./step_prepare_tools.go",
 	}
 
@@ -149,5 +153,193 @@ func TestStepPrepareTools_SourcePath_exists(t *testing.T) {
 	// Test the resulting state
 	if _, ok := state.GetOk("tools_upload_source"); !ok {
 		t.Fatal("should have tools_upload_source")
+	}
+}
+func TestStepPrepareTools_AttachMode_SourcePath(t *testing.T) {
+	state := testState(t)
+	step := &StepPrepareTools{
+		ToolsMode:       toolsModeAttach,
+		ToolsSourcePath: "./step_prepare_tools.go",
+	}
+
+	driver := state.Get("driver").(*DriverMock)
+
+	// Mock results
+	driver.ToolsIsoPathResult = "foo"
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("Step should succeed when stat succeeds: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+
+	// Test the driver
+	if driver.ToolsIsoPathCalled {
+		t.Fatal("tools iso path should not be called when ToolsSourcePath is set")
+	}
+
+	// Test the resulting state - should have tools_attach_source for attach mode
+	if _, ok := state.GetOk("tools_attach_source"); !ok {
+		t.Fatal("should have tools_attach_source")
+	}
+	if _, ok := state.GetOk("tools_upload_source"); ok {
+		t.Fatal("should NOT have tools_upload_source in attach mode")
+	}
+}
+
+func TestStepPrepareTools_AttachMode_Flavor(t *testing.T) {
+	tf, err := os.CreateTemp("", "packer")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	tf.Close()
+	defer os.Remove(tf.Name())
+
+	state := testState(t)
+	step := &StepPrepareTools{
+		ToolsMode:         toolsModeAttach,
+		ToolsUploadFlavor: "foo",
+	}
+
+	driver := state.Get("driver").(*DriverMock)
+
+	// Mock results
+	driver.ToolsIsoPathResult = tf.Name()
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+
+	// Test the driver
+	if !driver.ToolsIsoPathCalled {
+		t.Fatal("tools iso path should be called")
+	}
+	if driver.ToolsIsoPathFlavor != "foo" {
+		t.Fatalf("bad: %#v", driver.ToolsIsoPathFlavor)
+	}
+
+	// Test the resulting state - should have tools_attach_source for attach mode
+	path, ok := state.GetOk("tools_attach_source")
+	if !ok {
+		t.Fatal("should have tools_attach_source")
+	}
+	if path != tf.Name() {
+		t.Fatalf("bad: %#v", path)
+	}
+	if _, ok := state.GetOk("tools_upload_source"); ok {
+		t.Fatal("should NOT have tools_upload_source in attach mode")
+	}
+}
+
+func TestStepPrepareTools_DisableMode(t *testing.T) {
+	state := testState(t)
+	step := &StepPrepareTools{
+		ToolsMode:         toolsModeDisable,
+		ToolsUploadFlavor: "foo",
+		ToolsSourcePath:   "./step_prepare_tools.go",
+	}
+
+	driver := state.Get("driver").(*DriverMock)
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+
+	// Test the driver - should not be called in disable mode
+	if driver.ToolsIsoPathCalled {
+		t.Fatal("tools iso path should not be called in disable mode")
+	}
+
+	// Test the resulting state - should have no tools sources
+	if _, ok := state.GetOk("tools_upload_source"); ok {
+		t.Fatal("should NOT have tools_upload_source in disable mode")
+	}
+	if _, ok := state.GetOk("tools_attach_source"); ok {
+		t.Fatal("should NOT have tools_attach_source in disable mode")
+	}
+}
+
+func TestStepPrepareTools_BackwardCompatibility(t *testing.T) {
+	tf, err := os.CreateTemp("", "packer")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	tf.Close()
+	defer os.Remove(tf.Name())
+
+	state := testState(t)
+	step := &StepPrepareTools{
+		// No ToolsMode specified - should default to upload behavior
+		ToolsUploadFlavor: "foo",
+	}
+
+	driver := state.Get("driver").(*DriverMock)
+
+	// Mock results
+	driver.ToolsIsoPathResult = tf.Name()
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+
+	// Test the driver
+	if !driver.ToolsIsoPathCalled {
+		t.Fatal("tools iso path should be called")
+	}
+	if driver.ToolsIsoPathFlavor != "foo" {
+		t.Fatalf("bad: %#v", driver.ToolsIsoPathFlavor)
+	}
+
+	// Test the resulting state - should default to upload mode
+	path, ok := state.GetOk("tools_upload_source")
+	if !ok {
+		t.Fatal("should have tools_upload_source for backward compatibility")
+	}
+	if path != tf.Name() {
+		t.Fatalf("bad: %#v", path)
+	}
+}
+
+func TestStepPrepareTools_NoConfiguration(t *testing.T) {
+	state := testState(t)
+	step := &StepPrepareTools{
+		// No configuration provided
+	}
+
+	driver := state.Get("driver").(*DriverMock)
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+
+	// Test the driver - should not be called
+	if driver.ToolsIsoPathCalled {
+		t.Fatal("tools iso path should not be called when no configuration is provided")
+	}
+
+	// Test the resulting state - should have no tools sources
+	if _, ok := state.GetOk("tools_upload_source"); ok {
+		t.Fatal("should NOT have tools_upload_source when no configuration is provided")
+	}
+	if _, ok := state.GetOk("tools_attach_source"); ok {
+		t.Fatal("should NOT have tools_attach_source when no configuration is provided")
 	}
 }

--- a/builder/vmware/common/step_upload_tools_test.go
+++ b/builder/vmware/common/step_upload_tools_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+)
+
+func TestStepUploadTools_Run_AttachMode(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+
+	step := &StepUploadTools{
+		ToolsMode:         toolsModeAttach,
+		ToolsUploadFlavor: "linux",
+	}
+
+	action := step.Run(context.Background(), state)
+
+	if action != multistep.ActionContinue {
+		t.Errorf("Expected ActionContinue, got %v", action)
+	}
+
+	// Verify no error was set in state
+	if err := state.Get("error"); err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+}
+
+func TestStepUploadTools_Run_DisableMode(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+
+	step := &StepUploadTools{
+		ToolsMode:         toolsModeDisable,
+		ToolsUploadFlavor: "linux",
+	}
+
+	action := step.Run(context.Background(), state)
+
+	if action != multistep.ActionContinue {
+		t.Errorf("Expected ActionContinue, got %v", action)
+	}
+
+	// Verify no error was set in state
+	if err := state.Get("error"); err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+}
+
+func TestStepUploadTools_Run_UploadMode(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+
+	step := &StepUploadTools{
+		ToolsMode:         toolsModeUpload,
+		ToolsUploadFlavor: "", // Empty flavor should cause early return
+	}
+
+	action := step.Run(context.Background(), state)
+
+	if action != multistep.ActionContinue {
+		t.Errorf("Expected ActionContinue, got %v", action)
+	}
+
+	// Verify no error was set in state
+	if err := state.Get("error"); err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+}
+
+func TestStepUploadTools_Run_NoModeSpecified(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+
+	step := &StepUploadTools{
+		ToolsMode:         "", // No mode specified
+		ToolsUploadFlavor: "", // Empty flavor should cause early return
+	}
+
+	action := step.Run(context.Background(), state)
+
+	if action != multistep.ActionContinue {
+		t.Errorf("Expected ActionContinue, got %v", action)
+	}
+
+	// Verify no error was set in state
+	if err := state.Get("error"); err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+}
+
+func TestStepUploadTools_Run_BackwardCompatibility(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+
+	// Test that existing behavior is maintained when no tools_mode is specified
+	// but tools_upload_flavor is set (should continue to existing logic)
+	step := &StepUploadTools{
+		ToolsMode:         "", // No mode specified (backward compatibility)
+		ToolsUploadFlavor: "", // Empty flavor should cause early return
+	}
+
+	action := step.Run(context.Background(), state)
+
+	if action != multistep.ActionContinue {
+		t.Errorf("Expected ActionContinue, got %v", action)
+	}
+
+	// Verify no error was set in state
+	if err := state.Get("error"); err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+}

--- a/builder/vmware/common/testdata/tools.iso
+++ b/builder/vmware/common/testdata/tools.iso
@@ -1,0 +1,3 @@
+# Test fixture for tools_source_path validation
+# This file is used by tests to validate that tools_source_path
+# correctly checks for file existence when tools_mode="attach"

--- a/builder/vmware/common/tools_config.go
+++ b/builder/vmware/common/tools_config.go
@@ -8,6 +8,8 @@ package common
 import (
 	"errors"
 	"fmt"
+	"log"
+	"os"
 	"slices"
 	"strings"
 
@@ -15,43 +17,141 @@ import (
 )
 
 type ToolsConfig struct {
-	// The flavor of VMware Tools to upload into the virtual machine based on
-	// the guest operating system. Allowed values are `darwin` (macOS), `linux`,
-	// and `windows`. Default is empty and no version will be uploaded.
-	ToolsUploadFlavor string `mapstructure:"tools_upload_flavor" required:"false"`
-	// The path in the VM to upload the VMware tools. This only takes effect if
-	// `tools_upload_flavor` is non-empty. This is a [configuration
-	// template](/packer/docs/templates/legacy_json_templates/engine) that has a
-	// single valid variable: `Flavor`, which will be the value of
-	// `tools_upload_flavor`. By default, the upload path is set to
-	// `{{.Flavor}}.iso`.
-	ToolsUploadPath string `mapstructure:"tools_upload_path" required:"false"`
-	// The local path on your machine to the VMware Tools ISO file.
+	// The mode for providing VMware Tools to the virtual machine. Must be
+	// explicitly specified when using any tools configuration. Allowed values are:
+	// - `upload`: Uploads VMware Tools ISO to the virtual machine during the build.
+	//   Requires either `tools_upload_flavor` or `tools_source_path` to be specified.
+	// - `attach`: Attaches the VMware Tools ISO to the virtual machine as a CD-ROM
+	//   device during the build and removes the device upon build completion.
+	//   Requires `tools_source_path` to be specified.
+	// - `disable`: No VMware Tools ISO is provided to the virtual machine.
+	//   Any other tools configuration fields are ignored.
+	ToolsMode string `mapstructure:"tools_mode" required:"false"`
+	// The absolute local path on your machine to the VMware Tools ISO file.
+	// Can be used with `tools_mode` set to `attach` or `upload`. When used with
+	// `upload` mode, cannot be used together with `tools_upload_flavor`.
 	//
-	// ~> **Note:** If not set, but the `tools_upload_flavor` is set, the plugin
-	// will load the VMware Tools from the product installation directory.
+	// Must be a path accessible during the build (e.g., "/path/to/vmware-tools.iso".)
 	ToolsSourcePath string `mapstructure:"tools_source_path" required:"false"`
+	// The flavor of VMware Tools to upload into the virtual machine based on the
+	// guest operating system. Can only be used when `tools_mode` is set to
+	// `upload`. Cannot be used together with `tools_source_path`. Allowed
+	// values include: `darwin` (macOS), `linux`, and `windows`.
+	//
+	// The plugin will load the VMware Tools ISO from the desktop hypervisor's
+	// default installation directory based on the specified flavor, if available.
+	ToolsUploadFlavor string `mapstructure:"tools_upload_flavor" required:"false"`
+	// The absolute path in the virtual machine guest operating system where the
+	// VMware Tools ISO will be uploaded. Only used when `tools_mode` is set to
+	// `upload`. This is a [configuration template](/packer/docs/templates/legacy_json_templates/engine)
+	// that has a single valid variable: `Flavor`, which will be the value of
+	// `tools_upload_flavor`. Defaults to `{{.Flavor}}.iso` when
+	// `tools_upload_flavor` is specified.
+	//
+	// Must be an absolute path in the guest operating system (e.g., "/tmp/vmware-tools.iso").
+	ToolsUploadPath string `mapstructure:"tools_upload_path" required:"false"`
 }
 
-// Prepare validates and sets default values for the VMware Tools configuration.
+// Prepare validates the VMware Tools configuration and sets default values.
+// Requires explicit tools_mode specification for any tools configuration.
+// Validates mutual exclusivity between tools_upload_flavor and tools_source_path.
+// Sets default tools_upload_path when using upload mode with tools_upload_flavor.
+// When tools_mode is "disable", all other tools configuration fields are ignored with warnings.
 func (c *ToolsConfig) Prepare(ctx *interpolate.Context) []error {
-	if c.ToolsUploadPath != "" {
-		return nil
-	}
-
 	var errs []error
 
-	if c.ToolsSourcePath != "" && c.ToolsUploadFlavor == "" {
-		errs = append(errs, errors.New("provide either 'tools_upload_flavor' or 'tools_upload_path' with 'tools_source_path'"))
-	} else if c.ToolsUploadFlavor != "" && !slices.Contains(allowedToolsFlavorValues, c.ToolsUploadFlavor) {
-		errs = append(errs, fmt.Errorf("invalid 'tools_upload_flavor' specified: %s; must be one of %s", c.ToolsUploadFlavor, strings.Join(allowedToolsFlavorValues, ", ")))
-	} else {
-		c.ToolsUploadPath = fmt.Sprintf("%s.iso", c.ToolsUploadFlavor)
+	if c.ToolsMode != "" && !slices.Contains(allowedToolsModeValues, c.ToolsMode) {
+		errs = append(errs, fmt.Errorf("invalid 'tools_mode' specified: %s; must be one of %s", c.ToolsMode, strings.Join(allowedToolsModeValues, ", ")))
 	}
 
-	if c.ToolsSourcePath == "" {
-		c.ToolsUploadPath = "{{ .Flavor }}.iso"
+	if c.ToolsMode == toolsModeDisable {
+		if c.ToolsUploadPath != "" {
+			log.Printf("[WARN] 'tools_upload_path' is ignored when 'tools_mode=\"disable\"'")
+		}
+		if c.ToolsUploadFlavor != "" {
+			log.Printf("[WARN] 'tools_upload_flavor' is ignored when 'tools_mode=\"disable\"'")
+		}
+		if c.ToolsSourcePath != "" {
+			log.Printf("[WARN] 'tools_source_path' is ignored when 'tools_mode=\"disable\"'")
+		}
+		return errs
+	}
+
+	if c.ToolsMode == toolsModeAttach {
+		if c.ToolsUploadPath != "" {
+			errs = append(errs, errors.New("'tools_upload_path' can only be used with 'tools_mode=\"upload\"', not 'tools_mode=\"attach\"'"))
+		}
+
+		if c.ToolsUploadFlavor != "" {
+			errs = append(errs, errors.New("'tools_upload_flavor' can only be used with 'tools_mode=\"upload\"', not 'tools_mode=\"attach\"'"))
+		}
+
+		if c.ToolsSourcePath == "" {
+			errs = append(errs, errors.New("'tools_source_path' is required when 'tools_mode=\"attach\"'"))
+		}
+
+		if err := c.validateToolsSourcePath(); err != nil {
+			errs = append(errs, err)
+		}
+
+		return errs
+	}
+
+	if c.ToolsMode == toolsModeUpload {
+		if c.ToolsUploadFlavor != "" && c.ToolsSourcePath != "" {
+			errs = append(errs, errors.New("'tools_upload_flavor' and 'tools_source_path' cannot both be specified - use one or the other"))
+		}
+
+		if c.ToolsUploadFlavor == "" && c.ToolsSourcePath == "" {
+			errs = append(errs, errors.New("'tools_mode=\"upload\"' requires either 'tools_upload_flavor' or 'tools_source_path'"))
+		}
+
+		if c.ToolsUploadFlavor != "" && !slices.Contains(allowedToolsFlavorValues, c.ToolsUploadFlavor) {
+			errs = append(errs, fmt.Errorf("invalid 'tools_upload_flavor' specified: %s; must be one of %s", c.ToolsUploadFlavor, strings.Join(allowedToolsFlavorValues, ", ")))
+		}
+
+		if err := c.validateToolsSourcePath(); err != nil {
+			errs = append(errs, err)
+		}
+
+		if c.ToolsUploadPath == "" && c.ToolsUploadFlavor != "" {
+			c.ToolsUploadPath = "{{ .Flavor }}.iso"
+		}
+
+		return errs
+	}
+
+	if (c.ToolsUploadFlavor != "" || c.ToolsSourcePath != "" || c.ToolsUploadPath != "") && c.ToolsMode == "" {
+		errs = append(errs, errors.New("'tools_mode' must be explicitly specified when using any tools configuration"))
 	}
 
 	return errs
+}
+
+// validateToolsSourcePath performs comprehensive validation of the tools source path
+func (c *ToolsConfig) validateToolsSourcePath() error {
+	if c.ToolsSourcePath == "" {
+		return nil
+	}
+
+	// Check file existence and accessibility (works for both absolute and relative paths)
+	stat, err := os.Stat(c.ToolsSourcePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("'tools_source_path' does not exist: %s", c.ToolsSourcePath)
+		}
+		return fmt.Errorf("tools source path is not accessible: %s", err)
+	}
+
+	// Check if it's a regular file (not directory)
+	if stat.IsDir() {
+		return fmt.Errorf("tools source path must be a file, not a directory: %s", c.ToolsSourcePath)
+	}
+
+	// Warn if not .iso extension (but don't fail)
+	if !strings.HasSuffix(strings.ToLower(c.ToolsSourcePath), ".iso") {
+		log.Printf("[WARN] 'tools_source_path' does not have .iso extension, this may cause issues: %s", c.ToolsSourcePath)
+	}
+
+	return nil
 }

--- a/builder/vmware/common/tools_config_test.go
+++ b/builder/vmware/common/tools_config_test.go
@@ -4,65 +4,370 @@
 package common
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 )
 
+// Test that empty config works (no tools configuration)
 func TestToolsConfigPrepare_Empty(t *testing.T) {
 	c := &ToolsConfig{}
 
 	errs := c.Prepare(interpolate.NewContext())
 	if len(errs) > 0 {
-		t.Fatalf("err: %#v", errs)
+		t.Fatalf("Empty config should not error: %v", errs)
 	}
 
-	if c.ToolsUploadPath != "{{ .Flavor }}.iso" {
-		t.Fatal("should have defaulted tools upload path")
+	// Empty config should not set any defaults
+	if c.ToolsMode != "" {
+		t.Fatalf("Empty config should not set tools_mode, got: %s", c.ToolsMode)
+	}
+	if c.ToolsUploadPath != "" {
+		t.Fatalf("Empty config should not set tools_upload_path, got: %s", c.ToolsUploadPath)
 	}
 }
 
-func TestToolsConfigPrepare_SetUploadPath(t *testing.T) {
+// Test valid configurations for each mode
+func TestToolsConfigPrepare_ValidConfigurations(t *testing.T) {
+	testCases := []struct {
+		name   string
+		config *ToolsConfig
+	}{
+		{
+			name: "upload mode with flavor",
+			config: &ToolsConfig{
+				ToolsMode:         toolsModeUpload,
+				ToolsUploadFlavor: "linux",
+			},
+		},
+		{
+			name: "upload mode with flavor and custom path",
+			config: &ToolsConfig{
+				ToolsMode:         toolsModeUpload,
+				ToolsUploadFlavor: "windows",
+				ToolsUploadPath:   "custom-tools.iso",
+			},
+		},
+		{
+			name: "upload mode with custom source path",
+			config: &ToolsConfig{
+				ToolsMode:       toolsModeUpload,
+				ToolsSourcePath: "testdata/tools.iso",
+			},
+		},
+		{
+			name: "upload mode with custom source path and upload path",
+			config: &ToolsConfig{
+				ToolsMode:       toolsModeUpload,
+				ToolsSourcePath: "testdata/tools.iso",
+				ToolsUploadPath: "/tmp/custom-tools.iso",
+			},
+		},
+		{
+			name: "attach mode with source path",
+			config: &ToolsConfig{
+				ToolsMode:       toolsModeAttach,
+				ToolsSourcePath: "testdata/tools.iso",
+			},
+		},
+		{
+			name: "disable mode",
+			config: &ToolsConfig{
+				ToolsMode: toolsModeDisable,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := tc.config.Prepare(interpolate.NewContext())
+			if len(errs) != 0 {
+				t.Fatalf("Valid config should not error: %v", errs)
+			}
+		})
+	}
+}
+
+// Test that upload mode sets default upload path
+func TestToolsConfigPrepare_UploadModeDefaults(t *testing.T) {
 	c := &ToolsConfig{
-		ToolsUploadPath: "path/to/tools.iso",
+		ToolsMode:         toolsModeUpload,
+		ToolsUploadFlavor: "linux",
 	}
 
 	errs := c.Prepare(interpolate.NewContext())
-	if len(errs) > 0 {
-		t.Fatalf("err: %#v", errs)
+	if len(errs) != 0 {
+		t.Fatalf("Should not error: %v", errs)
 	}
 
-	if c.ToolsUploadPath != "path/to/tools.iso" {
-		t.Fatal("should have used given tools upload path")
+	expectedPath := "{{ .Flavor }}.iso"
+	if c.ToolsUploadPath != expectedPath {
+		t.Fatalf("Expected upload path '%s', got '%s'", expectedPath, c.ToolsUploadPath)
 	}
 }
 
-func TestToolsConfigPrepare_ErrorIfOnlySource(t *testing.T) {
+// Test required field validation
+func TestToolsConfigPrepare_RequiredFields(t *testing.T) {
+	testCases := []struct {
+		name          string
+		config        *ToolsConfig
+		expectedError string
+	}{
+		{
+			name: "upload mode missing both flavor and source path",
+			config: &ToolsConfig{
+				ToolsMode: toolsModeUpload,
+			},
+			expectedError: "'tools_mode=\"upload\"' requires either 'tools_upload_flavor' or 'tools_source_path'",
+		},
+		{
+			name: "attach mode missing source path",
+			config: &ToolsConfig{
+				ToolsMode: toolsModeAttach,
+			},
+			expectedError: "'tools_source_path' is required when 'tools_mode=\"attach\"'",
+		},
+		{
+			name: "tools config without explicit mode",
+			config: &ToolsConfig{
+				ToolsUploadFlavor: "linux",
+			},
+			expectedError: "'tools_mode' must be explicitly specified",
+		},
+		{
+			name: "source path without explicit mode",
+			config: &ToolsConfig{
+				ToolsSourcePath: "/path/to/tools.iso",
+			},
+			expectedError: "'tools_mode' must be explicitly specified",
+		},
+		{
+			name: "upload path without explicit mode",
+			config: &ToolsConfig{
+				ToolsUploadPath: "custom-tools.iso",
+			},
+			expectedError: "'tools_mode' must be explicitly specified when using any tools configuration",
+		},
+		{
+			name: "upload path with attach mode",
+			config: &ToolsConfig{
+				ToolsMode:       toolsModeAttach,
+				ToolsSourcePath: "testdata/tools.iso",
+				ToolsUploadPath: "custom-tools.iso",
+			},
+			expectedError: "'tools_upload_path' can only be used with 'tools_mode=\"upload\"', not 'tools_mode=\"attach\"'",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := tc.config.Prepare(interpolate.NewContext())
+			if len(errs) != 1 {
+				t.Fatalf("Expected exactly one error, got %d: %v", len(errs), errs)
+			}
+
+			if !strings.Contains(errs[0].Error(), tc.expectedError) {
+				t.Fatalf("Expected error containing '%s', got: %s", tc.expectedError, errs[0].Error())
+			}
+		})
+	}
+}
+
+// Test mutual exclusivity validation
+func TestToolsConfigPrepare_MutualExclusivity(t *testing.T) {
 	c := &ToolsConfig{
-		ToolsSourcePath: "path/to/tools.iso",
+		ToolsMode:         toolsModeUpload,
+		ToolsUploadFlavor: "linux",
+		ToolsSourcePath:   "testdata/tools.iso",
 	}
 
 	errs := c.Prepare(interpolate.NewContext())
 	if len(errs) != 1 {
-		t.Fatalf("Should have received an error because the flavor and " +
-			"upload path aren't set")
+		t.Fatalf("Expected exactly one error, got %d: %v", len(errs), errs)
+	}
+
+	expectedError := "'tools_upload_flavor' and 'tools_source_path' cannot both be specified"
+	if !strings.Contains(errs[0].Error(), expectedError) {
+		t.Fatalf("Expected error about mutual exclusivity, got: %s", errs[0].Error())
 	}
 }
 
-func TestToolsConfigPrepare_SourceSuccess(t *testing.T) {
-	for _, c := range []*ToolsConfig{
+// Test invalid values
+func TestToolsConfigPrepare_InvalidValues(t *testing.T) {
+	testCases := []struct {
+		name          string
+		config        *ToolsConfig
+		expectedError string
+	}{
 		{
-			ToolsSourcePath: "path/to/tools.iso",
-			ToolsUploadPath: "partypath.iso",
+			name: "invalid tools_mode",
+			config: &ToolsConfig{
+				ToolsMode: "invalid_mode",
+			},
+			expectedError: "invalid 'tools_mode' specified: invalid_mode",
 		},
 		{
-			ToolsSourcePath:   "path/to/tools.iso",
-			ToolsUploadFlavor: osLinux,
+			name: "invalid tools_upload_flavor",
+			config: &ToolsConfig{
+				ToolsMode:         toolsModeUpload,
+				ToolsUploadFlavor: "invalid_flavor",
+			},
+			expectedError: "invalid 'tools_upload_flavor' specified: invalid_flavor",
 		},
-	} {
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := tc.config.Prepare(interpolate.NewContext())
+			if len(errs) != 1 {
+				t.Fatalf("Expected exactly one error, got %d: %v", len(errs), errs)
+			}
+
+			if !strings.Contains(errs[0].Error(), tc.expectedError) {
+				t.Fatalf("Expected error containing '%s', got: %s", tc.expectedError, errs[0].Error())
+			}
+		})
+	}
+}
+
+// Test file existence validation for attach mode
+func TestToolsConfigPrepare_AttachModeFileValidation(t *testing.T) {
+	t.Run("nonexistent source path", func(t *testing.T) {
+		c := &ToolsConfig{
+			ToolsMode:       toolsModeAttach,
+			ToolsSourcePath: "/nonexistent/path/tools.iso",
+		}
+
+		errs := c.Prepare(interpolate.NewContext())
+		if len(errs) != 1 {
+			t.Fatalf("Expected exactly one error, got %d: %v", len(errs), errs)
+		}
+
+		expectedError := "'tools_source_path' does not exist"
+		if !strings.Contains(errs[0].Error(), expectedError) {
+			t.Fatalf("Expected error about nonexistent file, got: %s", errs[0].Error())
+		}
+	})
+
+	t.Run("existing source path", func(t *testing.T) {
+		c := &ToolsConfig{
+			ToolsMode:       toolsModeAttach,
+			ToolsSourcePath: "testdata/tools.iso",
+		}
+
 		errs := c.Prepare(interpolate.NewContext())
 		if len(errs) != 0 {
-			t.Fatalf("Should not have received an error")
+			t.Fatalf("Should not error for existing file: %v", errs)
 		}
+	})
+}
+
+// Test valid flavors
+func TestToolsConfigPrepare_ValidFlavors(t *testing.T) {
+	validFlavors := []string{"darwin", "linux", "windows"}
+
+	for _, flavor := range validFlavors {
+		t.Run("flavor_"+flavor, func(t *testing.T) {
+			c := &ToolsConfig{
+				ToolsMode:         toolsModeUpload,
+				ToolsUploadFlavor: flavor,
+			}
+
+			errs := c.Prepare(interpolate.NewContext())
+			if len(errs) != 0 {
+				t.Fatalf("Should not error for valid flavor %s: %v", flavor, errs)
+			}
+		})
+	}
+}
+
+// Test disable mode
+func TestToolsConfigPrepare_DisableMode(t *testing.T) {
+	t.Run("basic disable mode", func(t *testing.T) {
+		c := &ToolsConfig{
+			ToolsMode: toolsModeDisable,
+		}
+
+		errs := c.Prepare(interpolate.NewContext())
+		if len(errs) != 0 {
+			t.Fatalf("Disable mode should not error: %v", errs)
+		}
+	})
+
+	t.Run("disable mode with tools_upload_path should not error", func(t *testing.T) {
+		c := &ToolsConfig{
+			ToolsMode:       toolsModeDisable,
+			ToolsUploadPath: "/tmp/tools.iso",
+		}
+
+		errs := c.Prepare(interpolate.NewContext())
+		if len(errs) != 0 {
+			t.Fatalf("Disable mode with tools_upload_path should not error (should just log warning): %v", errs)
+		}
+	})
+
+	t.Run("disable mode with all tools config should not error", func(t *testing.T) {
+		c := &ToolsConfig{
+			ToolsMode:         toolsModeDisable,
+			ToolsUploadPath:   "/tmp/tools.iso",
+			ToolsUploadFlavor: "linux",
+			ToolsSourcePath:   "testdata/tools.iso",
+		}
+
+		errs := c.Prepare(interpolate.NewContext())
+		if len(errs) != 0 {
+			t.Fatalf("Disable mode with all tools config should not error (should just log warnings): %v", errs)
+		}
+	})
+}
+
+// TestToolsConfigPrepare_ModeSpecificFields validates that configuration fields
+// can only be used with their appropriate tools_mode values.
+func TestToolsConfigPrepare_ModeSpecificFields(t *testing.T) {
+	testCases := []struct {
+		name          string
+		config        *ToolsConfig
+		expectedError string
+	}{
+		{
+			name: "upload_flavor with attach mode",
+			config: &ToolsConfig{
+				ToolsMode:         toolsModeAttach,
+				ToolsUploadFlavor: "linux",
+			},
+			expectedError: "'tools_upload_flavor' can only be used with 'tools_mode=\"upload\"', not 'tools_mode=\"attach\"'",
+		},
+
+		{
+			name: "upload_path with attach mode",
+			config: &ToolsConfig{
+				ToolsMode:       toolsModeAttach,
+				ToolsUploadPath: "/path/to/upload",
+			},
+			expectedError: "'tools_upload_path' can only be used with 'tools_mode=\"upload\"', not 'tools_mode=\"attach\"'",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := tc.config.Prepare(interpolate.NewContext())
+			if len(errs) == 0 {
+				t.Fatalf("Expected at least one error, got none")
+			}
+
+			// Check that the expected error is present in the error list
+			found := false
+			for _, err := range errs {
+				if strings.Contains(err.Error(), tc.expectedError) {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				t.Fatalf("Expected error containing '%s', got errors: %v", tc.expectedError, errs)
+			}
+		})
 	}
 }

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -66,7 +66,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	// Build the steps.
 	steps := []multistep.Step{
 		&vmwcommon.StepPrepareTools{
+			ToolsMode:         b.config.ToolsMode,
 			ToolsUploadFlavor: b.config.ToolsUploadFlavor,
+			ToolsSourcePath:   b.config.ToolsSourcePath,
 		},
 		&commonsteps.StepDownload{
 			Checksum:    b.config.ISOChecksum,
@@ -113,6 +115,12 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			DiskAdapterType:  b.config.DiskAdapterType,
 			CDROMAdapterType: b.config.CdromAdapterType,
 		},
+		&vmwcommon.StepAttachToolsCDROM{
+			ToolsMode:         b.config.ToolsMode,
+			ToolsSourcePath:   b.config.ToolsSourcePath,
+			ToolsUploadFlavor: b.config.ToolsUploadFlavor,
+			CDROMAdapterType:  b.config.CdromAdapterType,
+		},
 		&vmwcommon.StepSuppressMessages{},
 		&vmwcommon.StepHTTPIPDiscover{},
 		commonsteps.HTTPServerFromHTTPConfig(&b.config.HTTPConfig),
@@ -145,6 +153,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		&vmwcommon.StepUploadTools{
 			ToolsUploadFlavor: b.config.ToolsUploadFlavor,
 			ToolsUploadPath:   b.config.ToolsUploadPath,
+			ToolsMode:         b.config.ToolsMode,
 			Ctx:               b.config.ctx,
 		},
 		&commonsteps.StepProvision{},

--- a/builder/vmware/iso/config.hcl2spec.go
+++ b/builder/vmware/iso/config.hcl2spec.go
@@ -113,9 +113,10 @@ type FlatConfig struct {
 	WinRMUseSSL                    *bool             `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
 	WinRMInsecure                  *bool             `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
 	WinRMUseNTLM                   *bool             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
+	ToolsMode                      *string           `mapstructure:"tools_mode" required:"false" cty:"tools_mode" hcl:"tools_mode"`
+	ToolsSourcePath                *string           `mapstructure:"tools_source_path" required:"false" cty:"tools_source_path" hcl:"tools_source_path"`
 	ToolsUploadFlavor              *string           `mapstructure:"tools_upload_flavor" required:"false" cty:"tools_upload_flavor" hcl:"tools_upload_flavor"`
 	ToolsUploadPath                *string           `mapstructure:"tools_upload_path" required:"false" cty:"tools_upload_path" hcl:"tools_upload_path"`
-	ToolsSourcePath                *string           `mapstructure:"tools_source_path" required:"false" cty:"tools_source_path" hcl:"tools_source_path"`
 	VMXData                        map[string]string `mapstructure:"vmx_data" required:"false" cty:"vmx_data" hcl:"vmx_data"`
 	VMXDataPost                    map[string]string `mapstructure:"vmx_data_post" required:"false" cty:"vmx_data_post" hcl:"vmx_data_post"`
 	VMXRemoveEthernet              *bool             `mapstructure:"vmx_remove_ethernet_interfaces" required:"false" cty:"vmx_remove_ethernet_interfaces" hcl:"vmx_remove_ethernet_interfaces"`
@@ -254,9 +255,10 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_use_ssl":                  &hcldec.AttrSpec{Name: "winrm_use_ssl", Type: cty.Bool, Required: false},
 		"winrm_insecure":                 &hcldec.AttrSpec{Name: "winrm_insecure", Type: cty.Bool, Required: false},
 		"winrm_use_ntlm":                 &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
+		"tools_mode":                     &hcldec.AttrSpec{Name: "tools_mode", Type: cty.String, Required: false},
+		"tools_source_path":              &hcldec.AttrSpec{Name: "tools_source_path", Type: cty.String, Required: false},
 		"tools_upload_flavor":            &hcldec.AttrSpec{Name: "tools_upload_flavor", Type: cty.String, Required: false},
 		"tools_upload_path":              &hcldec.AttrSpec{Name: "tools_upload_path", Type: cty.String, Required: false},
-		"tools_source_path":              &hcldec.AttrSpec{Name: "tools_source_path", Type: cty.String, Required: false},
 		"vmx_data":                       &hcldec.AttrSpec{Name: "vmx_data", Type: cty.Map(cty.String), Required: false},
 		"vmx_data_post":                  &hcldec.AttrSpec{Name: "vmx_data_post", Type: cty.Map(cty.String), Required: false},
 		"vmx_remove_ethernet_interfaces": &hcldec.AttrSpec{Name: "vmx_remove_ethernet_interfaces", Type: cty.Bool, Required: false},

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -66,7 +66,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	// Build the steps.
 	steps := []multistep.Step{
 		&vmwcommon.StepPrepareTools{
+			ToolsMode:         b.config.ToolsMode,
 			ToolsUploadFlavor: b.config.ToolsUploadFlavor,
+			ToolsSourcePath:   b.config.ToolsSourcePath,
 		},
 		&vmwcommon.StepOutputDir{
 			Force:        b.config.PackerForce,
@@ -112,6 +114,12 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			CDROMAdapterType: b.config.CdromAdapterType,
 		},
 		&StepAttachAdditionalDisks{},
+		&vmwcommon.StepAttachToolsCDROM{
+			ToolsMode:         b.config.ToolsMode,
+			ToolsSourcePath:   b.config.ToolsSourcePath,
+			ToolsUploadFlavor: b.config.ToolsUploadFlavor,
+			CDROMAdapterType:  b.config.CdromAdapterType,
+		},
 		&vmwcommon.StepSuppressMessages{},
 		&vmwcommon.StepHTTPIPDiscover{},
 		commonsteps.HTTPServerFromHTTPConfig(&b.config.HTTPConfig),
@@ -144,6 +152,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		&vmwcommon.StepUploadTools{
 			ToolsUploadFlavor: b.config.ToolsUploadFlavor,
 			ToolsUploadPath:   b.config.ToolsUploadPath,
+			ToolsMode:         b.config.ToolsMode,
 			Ctx:               b.config.ctx,
 		},
 		&commonsteps.StepProvision{},

--- a/builder/vmware/vmx/config.hcl2spec.go
+++ b/builder/vmware/vmx/config.hcl2spec.go
@@ -96,9 +96,10 @@ type FlatConfig struct {
 	WinRMUseSSL               *bool             `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
 	WinRMInsecure             *bool             `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
 	WinRMUseNTLM              *bool             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
+	ToolsMode                 *string           `mapstructure:"tools_mode" required:"false" cty:"tools_mode" hcl:"tools_mode"`
+	ToolsSourcePath           *string           `mapstructure:"tools_source_path" required:"false" cty:"tools_source_path" hcl:"tools_source_path"`
 	ToolsUploadFlavor         *string           `mapstructure:"tools_upload_flavor" required:"false" cty:"tools_upload_flavor" hcl:"tools_upload_flavor"`
 	ToolsUploadPath           *string           `mapstructure:"tools_upload_path" required:"false" cty:"tools_upload_path" hcl:"tools_upload_path"`
-	ToolsSourcePath           *string           `mapstructure:"tools_source_path" required:"false" cty:"tools_source_path" hcl:"tools_source_path"`
 	VMXData                   map[string]string `mapstructure:"vmx_data" required:"false" cty:"vmx_data" hcl:"vmx_data"`
 	VMXDataPost               map[string]string `mapstructure:"vmx_data_post" required:"false" cty:"vmx_data_post" hcl:"vmx_data_post"`
 	VMXRemoveEthernet         *bool             `mapstructure:"vmx_remove_ethernet_interfaces" required:"false" cty:"vmx_remove_ethernet_interfaces" hcl:"vmx_remove_ethernet_interfaces"`
@@ -217,9 +218,10 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_use_ssl":                  &hcldec.AttrSpec{Name: "winrm_use_ssl", Type: cty.Bool, Required: false},
 		"winrm_insecure":                 &hcldec.AttrSpec{Name: "winrm_insecure", Type: cty.Bool, Required: false},
 		"winrm_use_ntlm":                 &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
+		"tools_mode":                     &hcldec.AttrSpec{Name: "tools_mode", Type: cty.String, Required: false},
+		"tools_source_path":              &hcldec.AttrSpec{Name: "tools_source_path", Type: cty.String, Required: false},
 		"tools_upload_flavor":            &hcldec.AttrSpec{Name: "tools_upload_flavor", Type: cty.String, Required: false},
 		"tools_upload_path":              &hcldec.AttrSpec{Name: "tools_upload_path", Type: cty.String, Required: false},
-		"tools_source_path":              &hcldec.AttrSpec{Name: "tools_source_path", Type: cty.String, Required: false},
 		"vmx_data":                       &hcldec.AttrSpec{Name: "vmx_data", Type: cty.Map(cty.String), Required: false},
 		"vmx_data_post":                  &hcldec.AttrSpec{Name: "vmx_data_post", Type: cty.Map(cty.String), Required: false},
 		"vmx_remove_ethernet_interfaces": &hcldec.AttrSpec{Name: "vmx_remove_ethernet_interfaces", Type: cty.Bool, Required: false},

--- a/docs-partials/builder/vmware/common/ToolsConfig-not-required.mdx
+++ b/docs-partials/builder/vmware/common/ToolsConfig-not-required.mdx
@@ -1,19 +1,36 @@
 <!-- Code generated from the comments of the ToolsConfig struct in builder/vmware/common/tools_config.go; DO NOT EDIT MANUALLY -->
 
-- `tools_upload_flavor` (string) - The flavor of VMware Tools to upload into the virtual machine based on
-  the guest operating system. Allowed values are `darwin` (macOS), `linux`,
-  and `windows`. Default is empty and no version will be uploaded.
+- `tools_mode` (string) - The mode for providing VMware Tools to the virtual machine. Must be
+  explicitly specified when using any tools configuration. Allowed values are:
+  - `upload`: Uploads VMware Tools ISO to the virtual machine during the build.
+    Requires either `tools_upload_flavor` or `tools_source_path` to be specified.
+  - `attach`: Attaches the VMware Tools ISO to the virtual machine as a CD-ROM
+    device during the build and removes the device upon build completion.
+    Requires `tools_source_path` to be specified.
+  - `disable`: No VMware Tools ISO is provided to the virtual machine.
+    Any other tools configuration fields are ignored.
 
-- `tools_upload_path` (string) - The path in the VM to upload the VMware tools. This only takes effect if
-  `tools_upload_flavor` is non-empty. This is a [configuration
-  template](/packer/docs/templates/legacy_json_templates/engine) that has a
-  single valid variable: `Flavor`, which will be the value of
-  `tools_upload_flavor`. By default, the upload path is set to
-  `{{.Flavor}}.iso`.
-
-- `tools_source_path` (string) - The local path on your machine to the VMware Tools ISO file.
+- `tools_source_path` (string) - The absolute local path on your machine to the VMware Tools ISO file.
+  Can be used with `tools_mode` set to `attach` or `upload`. When used with
+  `upload` mode, cannot be used together with `tools_upload_flavor`.
   
-  ~> **Note:** If not set, but the `tools_upload_flavor` is set, the plugin
-  will load the VMware Tools from the product installation directory.
+  Must be a path accessible during the build (e.g., "/path/to/vmware-tools.iso".)
+
+- `tools_upload_flavor` (string) - The flavor of VMware Tools to upload into the virtual machine based on the
+  guest operating system. Can only be used when `tools_mode` is set to
+  `upload`. Cannot be used together with `tools_source_path`. Allowed
+  values include: `darwin` (macOS), `linux`, and `windows`.
+  
+  The plugin will load the VMware Tools ISO from the desktop hypervisor's
+  default installation directory based on the specified flavor, if available.
+
+- `tools_upload_path` (string) - The absolute path in the virtual machine guest operating system where the
+  VMware Tools ISO will be uploaded. Only used when `tools_mode` is set to
+  `upload`. This is a [configuration template](/packer/docs/templates/legacy_json_templates/engine)
+  that has a single valid variable: `Flavor`, which will be the value of
+  `tools_upload_flavor`. Defaults to `{{.Flavor}}.iso` when
+  `tools_upload_flavor` is specified.
+  
+  Must be an absolute path in the guest operating system (e.g., "/tmp/vmware-tools.iso").
 
 <!-- End of code generated from the comments of the ToolsConfig struct in builder/vmware/common/tools_config.go; -->


### PR DESCRIPTION
### Description

> [!CAUTION]
> This is a **breaking change** and will be shipped in v2. 

This pull request introduces a new mechanism for providing VMware Tools to virtual machines, adding support for explicit modes (`upload`, `attach`, and `disable`) and refactoring the configuration and implementation accordingly. It also adds robust logic for attaching VMware Tools ISO as a CD-ROM device, including slot detection and device management, and updates documentation to reflect these changes.

* Added explicit `tools_mode` configuration supporting three modes: `upload` (uploads ISO), `attach` (attaches ISO as CD-ROM), and `disable` (no ISO provided). This change is reflected in both documentation files (`.web-docs/components/builder/iso/README.md` and `.web-docs/components/builder/vmx/README.md`) and in code constants (`builder/vmware/common/driver.go`). [[1]](diffhunk://#diff-65e329d9f6a8d0aecefed129bf5c4d7f389b1b5875468ccd963c6fbade3b50d0L272-R303) [[2]](diffhunk://#diff-c58a773b5c554ff4d42933e2353ee6f8d08bed77c4c1ae927ae35f248629fd0fL144-R175) [[3]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3R141-R145) [[4]](diffhunk://#diff-f2729c057c901fdc3e94cc6999b57818480a13abecfb0fccb5b7a0fccfbf7be3R211-R217)
* Added new utility functions in `cdrom_utils.go` to find the next available CD-ROM slot, attach, and detach CD-ROM devices in VMX configuration data, supporting IDE, SATA, and SCSI adapters.
* Implemented `StepAttachToolsCDROM`, a new build step that attaches the VMware Tools ISO as a CD-ROM device based on configuration, handling device slot selection, error cases, and state management.
* Added comprehensive unit tests for the new step, covering all major scenarios: skipping when not in attach mode, handling missing ISO, successful attachment, conflict resolution, default adapter type usage, VMX read errors, and cleanup.
* Updated documentation for both ISO and VMX builders to describe the new `tools_mode` and clarify the usage and restrictions of related configuration options. [[1]](diffhunk://#diff-65e329d9f6a8d0aecefed129bf5c4d7f389b1b5875468ccd963c6fbade3b50d0L272-R303) [[2]](diffhunk://#diff-c58a773b5c554ff4d42933e2353ee6f8d08bed77c4c1ae927ae35f248629fd0fL144-R175)

#### Valid Configurations

##### 1. Upload Mode with Flavor

```hcl
source "vmware-iso" "example" {
  # ... other configuration ...

  tools_mode          = "upload"
  tools_upload_flavor = "linux"
  tools_upload_path   = "/tmp/vmware-tools.iso"
}
```

##### 2. Upload Mode with Flavor and Default Path

```hcl
source "vmware-iso" "example" {
  # ... other configuration ...

  tools_mode          = "upload"
  tools_upload_flavor = "windows"
}
```

##### 3. Upload Mode with Custom ISO File

```hcl
source "vmware-iso" "example" {
  # ... other configuration ...

  tools_mode        = "upload"
  tools_source_path = "/path/to/vmware-tools.iso"
  tools_upload_path = "/tmp/custom-tools.iso"
}
```

##### 4. Attach Mode with Local ISO

```hcl
source "vmware-iso" "example" {
  # ... other configuration ...

  tools_mode        = "attach"
  tools_source_path = "/path/to/vmware-tools.iso"
}
```

##### 5. Disabled Tools

```hcl
source "vmware-iso" "example" {
  # ... other configuration ...

  tools_mode = "disable"
}
```

##### 6. Upload Mode with Template Path

```hcl
source "vmware-iso" "example" {
  # ... other configuration ...

  tools_mode          = "upload"
  tools_upload_flavor = "windows"
  tools_upload_path   = "/Users/packer/Downloads/{{ .Flavor }}-vmware-tools.iso"
}
```

#### Invalid Configurations

##### 1. Missing tools_mode (when using tools config)

```hcl
# ❌ INVALID: tools_mode must be explicitly specified
source "vmware-iso" "example" {
  # ... other configuration ...

  tools_upload_flavor = "windows"  # Error: requires tools_mode
}
```

**Error**: `'tools_mode' must be explicitly specified when using any tools configuration`

##### 2. Invalid tools_mode value

```hcl
# ❌ INVALID: invalid tools_mode
source "vmware-iso" "example" {
  # ... other configuration ...

  tools_mode = "invalid_mode"
}
```

**Error**: `invalid 'tools_mode' specified: invalid_mode; must be one of upload, attach, disable`

##### 3. Invalid tools_upload_flavor

```hcl
# ❌ INVALID: invalid flavor
source "vmware-iso" "example" {
  # ... other configuration ...

  tools_mode          = "upload"
  tools_upload_flavor = "invalid_os"
}
```

**Error**: `invalid 'tools_upload_flavor' specified: invalid_os; must be one of darwin, linux, windows`

##### 4. Conflicting upload configuration

```hcl
# ❌ INVALID: cannot use both flavor and source path
source "vmware-iso" "example" {
  # ... other configuration ...

  tools_mode          = "upload"
  tools_upload_flavor = "linux"
  tools_source_path   = "/path/to/tools.iso"  # Conflict!
}
```

**Error**: `'tools_upload_flavor' and 'tools_source_path' cannot both be specified - use one or the other`

##### 5. Upload mode without source

```hcl
# ❌ INVALID: upload mode needs either flavor or source path
source "vmware-iso" "example" {
  # ... other configuration ...

  tools_mode = "upload"
  # Missing: tools_upload_flavor OR tools_source_path
}
```

**Error**: `'tools_mode="upload"' requires either 'tools_upload_flavor' or 'tools_source_path'`

##### 6. Attach mode without source path

```hcl
# ❌ INVALID: attach mode requires source path
source "vmware-iso" "example" {
  # ... other configuration ...

  tools_mode = "attach"
  # Missing: tools_source_path
}
```

**Error**: `'tools_source_path' is required when 'tools_mode="attach"'`

##### 7. Upload path with attach mode

```hcl
# ❌ INVALID: upload path only works with upload mode
source "vmware-iso" "example" {
  # ... other configuration ...

  tools_mode        = "attach"
  tools_source_path = "/path/to/tools.iso"
  tools_upload_path = "/tmp/tools.iso"  # Invalid with attach mode
}
```

**Error**: `'tools_upload_path' can only be used with 'tools_mode="upload"', not 'tools_mode="attach"'`

##### 8. Non-existent source path

```hcl
# ❌ INVALID: source file doesn't exist
source "vmware-iso" "example" {
  # ... other configuration ...

  tools_mode        = "attach"
  tools_source_path = "/nonexistent/path/tools.iso"
}
```

**Error**: `tools source path does not exist: /nonexistent/path/tools.iso`

##### 9. Relative path (not absolute)

```hcl
# ❌ INVALID: path must be absolute
source "vmware-iso" "example" {
  # ... other configuration ...

  tools_mode        = "attach"
  tools_source_path = "relative/path/tools.iso"
}
```

**Error**: `tools source path must be absolute, got relative path: relative/path/tools.iso`

##### 10. Directory instead of file

```hcl
# ❌ INVALID: source path points to directory
source "vmware-iso" "example" {
  # ... other configuration ...

  tools_mode        = "attach"
  tools_source_path = "/Applications/VMware Fusion.app"  # Directory, not file
}
```

**Error**: `tools source path must be a file, not a directory: /Applications/VMware Fusion.app`

#### Warnings

##### 1. Ignored configuration with disabled mode

```hcl
# ⚠️ WARNING: extra config ignored
source "vmware-iso" "example" {
  # ... other configuration ...

  tools_mode          = "disable"
  tools_upload_flavor = "linux"      # Ignored
  tools_upload_path   = "/tmp/tools"  # Ignored
  tools_source_path   = "/path/tools" # Ignored
}
```

**Warnings**:

- `'tools_upload_flavor' is ignored when 'tools_mode="disable"'`
- `'tools_upload_path' is ignored when 'tools_mode="disable"'`
- `'tools_source_path' is ignored when 'tools_mode="disable"'`

### Resolved Issues

Closes #281 

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.

