### PR TITLE
refactor(deps): switch vnc library to `tenthirtyam/go-vnc`

### DIFF
--- a/builder/vmware/common/step_vnc_boot_command.go
+++ b/builder/vmware/common/step_vnc_boot_command.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
-	"github.com/mitchellh/go-vnc"
+	"github.com/tenthirtyam/go-vnc"
 )
 
 // StepVNCBootCommand executes boot commands by sending keystrokes to the VM over VNC.

--- a/builder/vmware/common/step_vnc_connect.go
+++ b/builder/vmware/common/step_vnc_connect.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
-	"github.com/mitchellh/go-vnc"
+	"github.com/tenthirtyam/go-vnc"
 )
 
 // StepVNCConnect represents a step for establishing VNC connection to the virtual machine.
@@ -27,7 +27,7 @@ func (s *StepVNCConnect) Run(ctx context.Context, state multistep.StateBag) mult
 	ui := state.Get("ui").(packersdk.Ui)
 
 	ui.Say("Connecting to VNC...")
-	c, err := s.ConnectVNC(state)
+	c, err := s.ConnectVNC(ctx, state)
 	if err != nil {
 		err = fmt.Errorf("error connecting to VNC: %s", err)
 		state.Put("error", err)
@@ -40,7 +40,7 @@ func (s *StepVNCConnect) Run(ctx context.Context, state multistep.StateBag) mult
 }
 
 // ConnectVNC establishes a direct VNC connection to the virtual machine.
-func (s *StepVNCConnect) ConnectVNC(state multistep.StateBag) (*vnc.ClientConn, error) {
+func (s *StepVNCConnect) ConnectVNC(ctx context.Context, state multistep.StateBag) (*vnc.ClientConn, error) {
 	vncIp := state.Get("vnc_ip").(string)
 	vncPort := state.Get("vnc_port").(int)
 	vncPassword := state.Get("vnc_password")
@@ -57,7 +57,7 @@ func (s *StepVNCConnect) ConnectVNC(state multistep.StateBag) (*vnc.ClientConn, 
 		auth = []vnc.ClientAuth{&vnc.PasswordAuth{Password: vncPassword.(string)}}
 	}
 
-	c, err := vnc.Client(nc, &vnc.ClientConfig{Auth: auth, Exclusive: true})
+	c, err := vnc.ClientWithContext(ctx, nc, &vnc.ClientConfig{Auth: auth, Exclusive: true})
 	if err != nil {
 		err := fmt.Errorf("error handshaking with VNC: %s", err)
 		state.Put("error", err)

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/packer-plugin-sdk v0.6.3
-	github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed
 	github.com/stretchr/testify v1.11.1
+	github.com/tenthirtyam/go-vnc v1.0.0
 	github.com/zclconf/go-cty v1.16.4
 	golang.org/x/net v0.43.0
 	golang.org/x/sys v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -253,8 +253,6 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
-github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed h1:FI2NIv6fpef6BQl2u3IZX/Cj20tfypRF4yd+uaHOMtI=
-github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed/go.mod h1:3rdaFaCv4AyBgu5ALFM0+tSuHrBh6v692nyQe3ikrq0=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
@@ -332,6 +330,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tenthirtyam/go-vnc v1.0.0 h1:u0QZuuwPbrS4e5+3qlrTU9l9MdrH1blxt2Y49CxebgY=
+github.com/tenthirtyam/go-vnc v1.0.0/go.mod h1:uEdhZJMZGgrd0yVdF5N5CbWgsjKTYzaZfqcvuws8JKA=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.2.6/go.mod h1:anCg0y61KIhDlPZmnH+so+RQbysYVyDko0IMgJv0Nn0=
 github.com/ugorji/go/codec v1.2.6 h1:7kbGefxLoDBuYXOms4yD7223OpNMMPNPZxXk5TvFcyQ=


### PR DESCRIPTION
### Description

Replaced the deprecated/archived `mitchellh/go-vnc` library with `tenthirtyam/go-vnc`. Updated method signatures and usage to match the new library's API for improved VNC connection handling.

Dependency Update:

* Replaced the `github.com/mitchellh/go-vnc` dependency with `github.com/tenthirtyam/go-vnc v1.0.0` in `go.mod` and all relevant imports. [[1]](diffhunk://#diff-e7d304c44ccc1f16646595ce0d8174875c322769b71a361ffda27440f4f285f1L17-R17) [[2]](diffhunk://#diff-3e7e9fecf2da616495990c6c91245d6affda62cb5e489e6248d1e5e7305a8e0fL13-R13) [[3]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L10-R11)

Connection Improvements:

* Refactored the `ConnectVNC` method in `step_vnc_connect.go` to accept a `context.Context` parameter and use the new `ClientWithContext` function for VNC connection, enhancing context management and cancellation support. [[1]](diffhunk://#diff-3e7e9fecf2da616495990c6c91245d6affda62cb5e489e6248d1e5e7305a8e0fL43-R43) [[2]](diffhunk://#diff-3e7e9fecf2da616495990c6c91245d6affda62cb5e489e6248d1e5e7305a8e0fL60-R60)
* Updated the call to `ConnectVNC` in the `Run` method to pass the context, ensuring consistent context propagation.

### Resolved Issues

Replaced the deprecated/archived `mitchellh/go-vnc` library with `tenthirtyam/go-vnc`. Updated method signatures and usage to match the new library's API for improved VNC connection handling.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.

