### PR TITLE
refactor: use nil slice declaration

### DIFF
--- a/builder/vmware/common/step_clean_vmx.go
+++ b/builder/vmware/common/step_clean_vmx.go
@@ -34,7 +34,7 @@ func (s StepCleanVMX) cleanupToolsCDROM(ui packersdk.Ui, vmxData map[string]stri
 	ui.Sayf("Removing VMware Tools ISO CD-ROM device %s...", devicePath)
 
 	// Remove all VMX entries for the tools CD-ROM device
-	keysToDelete := []string{}
+	var keysToDelete []string
 	devicePrefix := fmt.Sprintf("%s.", devicePath)
 
 	for key := range vmxData {


### PR DESCRIPTION
### Description

Replaces empty slice declaration with nil slice declaration.

An empty slice can be represented by nil or an empty slice literal. They are functionally equivalent — their len and cap are both zero — but the nil slice is the preferred style.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.

