### PR TITLE
refactor: add support for usb 3.2

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -140,8 +140,12 @@ JSON Example:
   ~> **Note:** Automatically enabled on Apple Silicon-based systems to
   ensure plugin functionality.
 
-- `usb_version` (string) - USB version to use when USB is enabled. Defaults to "2.0".
-  Allowed values are "2.0" and "3.1".
+- `usb_version` (string) - USB version to use when USB is enabled. Defaults to `3.1`.
+  Allowed values are `2.0`, `3.1`, and `3.2`.
+  
+  ~> **Note:** Both `3.2` and `3.1` produce an identical configuration
+  for the virtual machine. VMware Fusion and Workstation 25H2 and
+  later use `3.2`, whereas previous versions use `3.1`.
   
   ~> **Note:** Automatically set on Apple Silicon-based systems to ensure
   plugin functionality.
@@ -158,16 +162,16 @@ JSON Example:
       port. By default, the builder will assume this as `FALSE`.
   
   * `DEVICE:path(,yield)` - Specifies the path to the local device to be
-     used as the serial port. If `path` is empty, then default to the first
-    serial port.
+       used as the serial port. If `path` is empty, then default to the first
+     serial port.
   
     * `yield` (bool) - This is an optional boolean that specifies
       whether the virtual machine should yield the CPU when polling the
       port. By default, the builder will assume this as `FALSE`.
   
   * `PIPE:path,endpoint,host(,yield)` - Specifies to use the named-pipe
-    "path" as a serial port. This has a few options that determine how the
-    VM should use the named-pipe.
+     "path" as a serial port. This has a few options that determine how the
+     VM should use the named-pipe.
   
     * `endpoint` (string) - Chooses the type of the VM-end, which can be
       either a `client` or `server`.
@@ -180,8 +184,8 @@ JSON Example:
       default, the builder will assume this as `FALSE`.
   
   * `AUTO: (yield)` - Specifies to use auto-detection to determine the
-    serial port to use. This has one option to determine how the virtual
-    machine should support the serial port.
+     serial port to use. This has one option to determine how the virtual
+     machine should support the serial port.
   
     * `yield` (bool) - This is an optional boolean that specifies whether
       the virtual machine should yield the CPU when polling the port. By
@@ -200,8 +204,8 @@ JSON Example:
      the parallel port.
   
   * `AUTO:direction` - Specifies to use auto-detection to determine the
-    parallel port. Direction can be `BI` to specify bidirectional
-    communication or `UNI` to specify unidirectional communication.
+     parallel port. Direction can be `BI` to specify bidirectional
+     communication or `UNI` to specify unidirectional communication.
   
   * `NONE` - Specifies to not use a parallel port. (default)
 

--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -127,6 +127,7 @@ const (
 	// USB version types.
 	UsbVersion20 = "2.0"
 	UsbVersion31 = "3.1"
+	UsbVersion32 = "3.2"
 
 	// Shutdown operation timings.
 	shutdownPollInterval     = 150 * time.Millisecond
@@ -215,6 +216,7 @@ var AllowedCdromAdapterTypes = []string{
 var AllowedUsbVersions = []string{
 	UsbVersion20,
 	UsbVersion31,
+	UsbVersion32,
 }
 
 // The allowed values for the `ToolsMode`.

--- a/builder/vmware/common/hw_config.go
+++ b/builder/vmware/common/hw_config.go
@@ -52,8 +52,12 @@ type HWConfig struct {
 	// ~> **Note:** Automatically enabled on Apple Silicon-based systems to
 	// ensure plugin functionality.
 	USB bool `mapstructure:"usb" required:"false"`
-	// USB version to use when USB is enabled. Defaults to "2.0".
-	// Allowed values are "2.0" and "3.1".
+	// USB version to use when USB is enabled. Defaults to `3.1`.
+	// Allowed values are `2.0`, `3.1`, and `3.2`.
+	//
+	// ~> **Note:** Both `3.2` and `3.1` produce an identical configuration
+	// for the virtual machine. VMware Fusion and Workstation 25H2 and
+	// later use `3.2`, whereas previous versions use `3.1`.
 	//
 	// ~> **Note:** Automatically set on Apple Silicon-based systems to ensure
 	// plugin functionality.
@@ -70,16 +74,16 @@ type HWConfig struct {
 	//     port. By default, the builder will assume this as `FALSE`.
 	//
 	// * `DEVICE:path(,yield)` - Specifies the path to the local device to be
-	//   used as the serial port. If `path` is empty, then default to the first
-	//   serial port.
+	//      used as the serial port. If `path` is empty, then default to the first
+	//    serial port.
 	//
 	//   * `yield` (bool) - This is an optional boolean that specifies
 	//     whether the virtual machine should yield the CPU when polling the
 	//     port. By default, the builder will assume this as `FALSE`.
 	//
 	// * `PIPE:path,endpoint,host(,yield)` - Specifies to use the named-pipe
-	//   "path" as a serial port. This has a few options that determine how the
-	//   VM should use the named-pipe.
+	//    "path" as a serial port. This has a few options that determine how the
+	//    VM should use the named-pipe.
 	//
 	//   * `endpoint` (string) - Chooses the type of the VM-end, which can be
 	//     either a `client` or `server`.
@@ -92,8 +96,8 @@ type HWConfig struct {
 	//     default, the builder will assume this as `FALSE`.
 	//
 	// * `AUTO: (yield)` - Specifies to use auto-detection to determine the
-	//   serial port to use. This has one option to determine how the virtual
-	//   machine should support the serial port.
+	//    serial port to use. This has one option to determine how the virtual
+	//    machine should support the serial port.
 	//
 	//   * `yield` (bool) - This is an optional boolean that specifies whether
 	//     the virtual machine should yield the CPU when polling the port. By
@@ -112,8 +116,8 @@ type HWConfig struct {
 	//    the parallel port.
 	//
 	// * `AUTO:direction` - Specifies to use auto-detection to determine the
-	//   parallel port. Direction can be `BI` to specify bidirectional
-	//   communication or `UNI` to specify unidirectional communication.
+	//    parallel port. Direction can be `BI` to specify bidirectional
+	//    communication or `UNI` to specify unidirectional communication.
 	//
 	// * `NONE` - Specifies to not use a parallel port. (default)
 	Parallel string `mapstructure:"parallel" required:"false"`
@@ -151,7 +155,7 @@ func (c *HWConfig) Prepare(ctx *interpolate.Context) []error {
 
 	if c.USB {
 		if c.USBVersion == "" {
-			c.USBVersion = UsbVersion20
+			c.USBVersion = UsbVersion31
 		}
 
 		if !slices.Contains(AllowedUsbVersions, c.USBVersion) {
@@ -164,9 +168,9 @@ func (c *HWConfig) Prepare(ctx *interpolate.Context) []error {
 	// VMware Fusion on Apple Silicon requires USB controllers for the plugin
 	// to work properly. Auto-enable if not explicitly configured.
 	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" && !c.USB && c.USBVersion == "" {
-		log.Printf("[INFO] Auto-enabling USB 2.0 on Apple Silicon for plugin functionality")
+		log.Printf("[INFO] Auto-enabling USB 3.1 on Apple Silicon for plugin functionality")
 		c.USB = true
-		c.USBVersion = UsbVersion20
+		c.USBVersion = UsbVersion31
 	}
 
 	if c.Parallel == "" {

--- a/builder/vmware/common/hw_config_test.go
+++ b/builder/vmware/common/hw_config_test.go
@@ -40,8 +40,8 @@ func TestHWConfigPrepare(t *testing.T) {
 		if !c.USB {
 			t.Errorf("USB should be automatically enabled on Apple Silicon: %t", c.USB)
 		}
-		if c.USBVersion != UsbVersion20 {
-			t.Errorf("USB version should be automatically set to 2.0 on Apple Silicon: %s", c.USBVersion)
+		if c.USBVersion != UsbVersion31 {
+			t.Errorf("USB version should be automatically set to 3.1 on Apple Silicon: %s", c.USBVersion)
 		}
 	} else {
 		if c.USB {
@@ -363,7 +363,7 @@ func TestHWConfigUSBValidation_USB2Only(t *testing.T) {
 	}
 }
 
-func TestHWConfigUSBValidation_USB3Only(t *testing.T) {
+func TestHWConfigUSBValidation_USB31Only(t *testing.T) {
 	c := new(HWConfig)
 	c.NetworkAdapterType = "vmxnet3"
 	c.USB = true
@@ -382,11 +382,30 @@ func TestHWConfigUSBValidation_USB3Only(t *testing.T) {
 	}
 }
 
+func TestHWConfigUSBValidation_USB32Only(t *testing.T) {
+	c := new(HWConfig)
+	c.NetworkAdapterType = "vmxnet3"
+	c.USB = true
+	c.USBVersion = UsbVersion32
+
+	if errs := c.Prepare(interpolate.NewContext()); len(errs) > 0 {
+		t.Fatalf("err: %#v", errs)
+	}
+
+	if !c.USB {
+		t.Errorf("USB should be enabled: %t", c.USB)
+	}
+
+	if c.USBVersion != UsbVersion32 {
+		t.Errorf("USB version should be 3.2: %s", c.USBVersion)
+	}
+}
+
 func TestHWConfigUSBValidation_USBVersionDefault(t *testing.T) {
 	c := new(HWConfig)
 	c.NetworkAdapterType = "vmxnet3"
 	c.USB = true
-	// Don't set USBVersion, should default to 2.0
+	// Don't set USBVersion, should default to 3.1
 
 	errs := c.Prepare(interpolate.NewContext())
 	if len(errs) > 0 {
@@ -397,8 +416,8 @@ func TestHWConfigUSBValidation_USBVersionDefault(t *testing.T) {
 		t.Errorf("USB should be enabled: %t", c.USB)
 	}
 
-	if c.USBVersion != UsbVersion20 {
-		t.Errorf("USB version should default to 2.0: %s", c.USBVersion)
+	if c.USBVersion != UsbVersion31 {
+		t.Errorf("USB version should default to 3.1: %s", c.USBVersion)
 	}
 }
 
@@ -414,8 +433,8 @@ func TestHWConfigUSBValidation_USBDisabled(t *testing.T) {
 		if !c.USB {
 			t.Errorf("USB should be automatically enabled on Apple Silicon: %t", c.USB)
 		}
-		if c.USBVersion != UsbVersion20 {
-			t.Errorf("USB version should be automatically set to 2.0 on Apple Silicon: %s", c.USBVersion)
+		if c.USBVersion != UsbVersion31 {
+			t.Errorf("USB version should be automatically set to 3.1 on Apple Silicon: %s", c.USBVersion)
 		}
 	} else {
 		if c.USB {
@@ -438,7 +457,7 @@ func TestHWConfigUSBValidation_InvalidVersion(t *testing.T) {
 		t.Fatal("expected validation error for invalid USB version")
 	}
 
-	expectedError := "invalid 'usb_version' specified: 1.1; must be one of 2.0, 3.1"
+	expectedError := "invalid 'usb_version' specified: 1.1; must be one of 2.0, 3.1, 3.2"
 	found := false
 	for _, err := range errs {
 		if err.Error() == expectedError {

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -507,7 +507,7 @@ sound.autodetect = "TRUE"
 // USB Controllers
 {{ if .UsbPresent }}usb.present = "{{ .UsbPresent }}"{{ end }}
 {{ if .UsbPresent }}ehci.present = "{{ .UsbPresent }}"{{ end }}
-{{ if and .UsbPresent (eq .UsbVersion "3.1") }}usb_xhci.present = "{{ .UsbPresent }}"{{ end }}
+{{ if and .UsbPresent (or (eq .UsbVersion "3.1") (eq .UsbVersion "3.2")) }}usb_xhci.present = "{{ .UsbPresent }}"{{ end }}
 
 // Serial
 serial0.present = "{{ .SerialPresent }}"

--- a/builder/vmware/iso/step_create_vmx_test.go
+++ b/builder/vmware/iso/step_create_vmx_test.go
@@ -433,7 +433,7 @@ func TestStepCreateVmx_Usb3(t *testing.T) {
 	acctest.TestPlugin(t, testCase)
 }
 
-func TestVMXTemplateData_USB3Enabled(t *testing.T) {
+func TestVMXTemplateData_USB31Enabled(t *testing.T) {
 	templateData := vmxTemplateData{
 		Name:                           "test-vm",
 		GuestOS:                        "ubuntu-64",
@@ -467,6 +467,43 @@ func TestVMXTemplateData_USB3Enabled(t *testing.T) {
 
 	if !strings.Contains(result, "usb.present = \"TRUE\"") {
 		t.Error("Expected usb.present = \"TRUE\" in VMX output when USB 3.1 is enabled")
+	}
+}
+
+func TestVMXTemplateData_USB32Enabled(t *testing.T) {
+	templateData := vmxTemplateData{
+		Name:                           "test-vm",
+		GuestOS:                        "ubuntu-64",
+		Version:                        "18",
+		CpuCount:                       "2",
+		MemorySize:                     "1024",
+		DiskName:                       "test-disk",
+		ISOPath:                        "/path/to/test.iso",
+		NetworkType:                    "nat",
+		NetworkDevice:                  "",
+		NetworkAdapter:                 "e1000",
+		SoundPresent:                   "FALSE",
+		UsbPresent:                     "TRUE",
+		UsbVersion:                     common.UsbVersion32,
+		SerialPresent:                  "FALSE",
+		ParallelPresent:                "FALSE",
+		HardwareAssistedVirtualization: false,
+	}
+
+	ctx := interpolate.Context{}
+	ctx.Data = &templateData
+
+	result, err := interpolate.Render(DefaultVMXTemplate, &ctx)
+	if err != nil {
+		t.Fatalf("Failed to render VMX template: %s", err)
+	}
+
+	if !strings.Contains(result, "usb_xhci.present = \"TRUE\"") {
+		t.Error("Expected usb_xhci.present = \"TRUE\" in VMX output when USB 3.2 is enabled")
+	}
+
+	if !strings.Contains(result, "usb.present = \"TRUE\"") {
+		t.Error("Expected usb.present = \"TRUE\" in VMX output when USB 3.2 is enabled")
 	}
 }
 
@@ -558,6 +595,13 @@ func TestVMXTemplateData_PopulationFromConfig(t *testing.T) {
 			usbVersion:  common.UsbVersion31,
 			expectedUSB: "TRUE",
 			expectedVer: common.UsbVersion31,
+		},
+		{
+			name:        "USB 3.2 enabled",
+			usbConfig:   true,
+			usbVersion:  common.UsbVersion32,
+			expectedUSB: "TRUE",
+			expectedVer: common.UsbVersion32,
 		},
 		{
 			name:        "USB 2.0 enabled",

--- a/docs-partials/builder/vmware/common/HWConfig-not-required.mdx
+++ b/docs-partials/builder/vmware/common/HWConfig-not-required.mdx
@@ -35,8 +35,12 @@
   ~> **Note:** Automatically enabled on Apple Silicon-based systems to
   ensure plugin functionality.
 
-- `usb_version` (string) - USB version to use when USB is enabled. Defaults to "2.0".
-  Allowed values are "2.0" and "3.1".
+- `usb_version` (string) - USB version to use when USB is enabled. Defaults to `3.1`.
+  Allowed values are `2.0`, `3.1`, and `3.2`.
+  
+  ~> **Note:** Both `3.2` and `3.1` produce an identical configuration
+  for the virtual machine. VMware Fusion and Workstation 25H2 and
+  later use `3.2`, whereas previous versions use `3.1`.
   
   ~> **Note:** Automatically set on Apple Silicon-based systems to ensure
   plugin functionality.
@@ -53,16 +57,16 @@
       port. By default, the builder will assume this as `FALSE`.
   
   * `DEVICE:path(,yield)` - Specifies the path to the local device to be
-     used as the serial port. If `path` is empty, then default to the first
-    serial port.
+       used as the serial port. If `path` is empty, then default to the first
+     serial port.
   
     * `yield` (bool) - This is an optional boolean that specifies
       whether the virtual machine should yield the CPU when polling the
       port. By default, the builder will assume this as `FALSE`.
   
   * `PIPE:path,endpoint,host(,yield)` - Specifies to use the named-pipe
-    "path" as a serial port. This has a few options that determine how the
-    VM should use the named-pipe.
+     "path" as a serial port. This has a few options that determine how the
+     VM should use the named-pipe.
   
     * `endpoint` (string) - Chooses the type of the VM-end, which can be
       either a `client` or `server`.
@@ -75,8 +79,8 @@
       default, the builder will assume this as `FALSE`.
   
   * `AUTO: (yield)` - Specifies to use auto-detection to determine the
-    serial port to use. This has one option to determine how the virtual
-    machine should support the serial port.
+     serial port to use. This has one option to determine how the virtual
+     machine should support the serial port.
   
     * `yield` (bool) - This is an optional boolean that specifies whether
       the virtual machine should yield the CPU when polling the port. By
@@ -95,8 +99,8 @@
      the parallel port.
   
   * `AUTO:direction` - Specifies to use auto-detection to determine the
-    parallel port. Direction can be `BI` to specify bidirectional
-    communication or `UNI` to specify unidirectional communication.
+     parallel port. Direction can be `BI` to specify bidirectional
+     communication or `UNI` to specify unidirectional communication.
   
   * `NONE` - Specifies to not use a parallel port. (default)
 


### PR DESCRIPTION
### Description

Refactors the `usb_version` to account for USB 3.2 in VMware Fusion and Workstation 25H2 - though it's the exact same resulting configuration as 3.1.

### Resolved Issues

Closes #391 

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.

