### PR TITLE
Fixed documentation of vmx_data_post

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -730,7 +730,7 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
   not necessary for most users.
 
 - `vmx_data_post` (map[string]string) - Key-value pairs that will be inserted into the virtual machine `.vmx`
-  file **after** the virtual machine is started. This is useful for setting
+  file **after** the virtual machine build is **complete**. This is useful for setting
   advanced properties that are not supported by the plugin.
   
   ~> **Note**: This option is intended for advanced users who understand

--- a/.web-docs/components/builder/vmx/README.md
+++ b/.web-docs/components/builder/vmx/README.md
@@ -506,7 +506,7 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
   not necessary for most users.
 
 - `vmx_data_post` (map[string]string) - Key-value pairs that will be inserted into the virtual machine `.vmx`
-  file **after** the virtual machine is started. This is useful for setting
+  file **after** the virtual machine build is **complete**. This is useful for setting
   advanced properties that are not supported by the plugin.
   
   ~> **Note**: This option is intended for advanced users who understand

--- a/docs-partials/builder/vmware/common/VMXConfig-not-required.mdx
+++ b/docs-partials/builder/vmware/common/VMXConfig-not-required.mdx
@@ -9,7 +9,7 @@
   not necessary for most users.
 
 - `vmx_data_post` (map[string]string) - Key-value pairs that will be inserted into the virtual machine `.vmx`
-  file **after** the virtual machine is started. This is useful for setting
+  file **after** the virtual machine build is **complete**. This is useful for setting
   advanced properties that are not supported by the plugin.
   
   ~> **Note**: This option is intended for advanced users who understand


### PR DESCRIPTION
(I ommited the whole creating-a-brunch thingy because it's literally three words that need to be changed in a Markdown file...)

### Description
> What code changed, and why?

Not really a code change, it's a fix in the documentation.
The current documentation (see https://developer.hashicorp.com/packer/integrations/hashicorp/vmware/latest/components/builder/iso#advanced-configuration ) states:

> vmx_data_post (map[string]string) - Key-value pairs that will be inserted into the virtual machine .vmx file **after the virtual machine is started**. This is useful for setting advanced properties that are not supported by the plugin.

I was looking for a way to change the network adapter from NAT to Host-Only after my VM finished the whole provisioning. I knew I've done something similar recently with Parallels (where they have the `prlctl_post`, which is "run after the virtual machine is shutdown, and before the virtual machine is exported", which is why I found strange that this `vmx_data_post` was run after the machine was started (??)

Anyways, I tried this setting
```
vmx_data_post = {
	"ethernet0.connectiontype" = "hostonly"
}
```
and, alas, the config was changed after all my provisioning was finished.

So, the documentation of that parameter is wrong, hence my PR.

<br/>

For what is worth, the `vmx_data_post` parameter is mentioned in another infobox (see the note down in the https://developer.hashicorp.com/packer/integrations/hashicorp/vmware/latest/components/builder/iso#boot-configuration section), where it is correctly documented:
> (...) use the vmx_data_post hook to modify the network configuration **after the virtual machine build is complete**.

For consistency, I just copied that sentence over to the wrong sections.


### Resolved Issues
> If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

(N/A)

### Rollback Plan

> If a change needs to be reverted, we will roll out an update to the code within 7 days.

(N/A)

### Changes to Security Controls

> Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

(N/A)
