### PR TITLE
docs: update `vmx_data_post`

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -722,7 +722,7 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
 <!-- Code generated from the comments of the VMXConfig struct in builder/vmware/common/vmx_config.go; DO NOT EDIT MANUALLY -->
 
 - `vmx_data` (map[string]string) - Key-value pairs that will be inserted into the virtual machine `.vmx`
-  file **before** the virtual machine is started. This is useful for
+  file before the virtual machine is started. This is useful for
   setting advanced properties that are not supported by the plugin.
   
   ~> **Note**: This option is intended for advanced users who understand
@@ -730,8 +730,8 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
   not necessary for most users.
 
 - `vmx_data_post` (map[string]string) - Key-value pairs that will be inserted into the virtual machine `.vmx`
-  file **after** the virtual machine is started. This is useful for setting
-  advanced properties that are not supported by the plugin.
+  file after the virtual machine build is complete. This is useful for
+  setting advanced properties that are not supported by the plugin.
   
   ~> **Note**: This option is intended for advanced users who understand
   the ramifications of making changes to the `.vmx` file. This option is

--- a/.web-docs/components/builder/vmx/README.md
+++ b/.web-docs/components/builder/vmx/README.md
@@ -498,7 +498,7 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
 <!-- Code generated from the comments of the VMXConfig struct in builder/vmware/common/vmx_config.go; DO NOT EDIT MANUALLY -->
 
 - `vmx_data` (map[string]string) - Key-value pairs that will be inserted into the virtual machine `.vmx`
-  file **before** the virtual machine is started. This is useful for
+  file before the virtual machine is started. This is useful for
   setting advanced properties that are not supported by the plugin.
   
   ~> **Note**: This option is intended for advanced users who understand
@@ -506,8 +506,8 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
   not necessary for most users.
 
 - `vmx_data_post` (map[string]string) - Key-value pairs that will be inserted into the virtual machine `.vmx`
-  file **after** the virtual machine is started. This is useful for setting
-  advanced properties that are not supported by the plugin.
+  file after the virtual machine build is complete. This is useful for
+  setting advanced properties that are not supported by the plugin.
   
   ~> **Note**: This option is intended for advanced users who understand
   the ramifications of making changes to the `.vmx` file. This option is

--- a/builder/vmware/common/vmx_config.go
+++ b/builder/vmware/common/vmx_config.go
@@ -11,7 +11,7 @@ import (
 
 type VMXConfig struct {
 	// Key-value pairs that will be inserted into the virtual machine `.vmx`
-	// file **before** the virtual machine is started. This is useful for
+	// file before the virtual machine is started. This is useful for
 	// setting advanced properties that are not supported by the plugin.
 	//
 	// ~> **Note**: This option is intended for advanced users who understand
@@ -19,8 +19,8 @@ type VMXConfig struct {
 	// not necessary for most users.
 	VMXData map[string]string `mapstructure:"vmx_data" required:"false"`
 	// Key-value pairs that will be inserted into the virtual machine `.vmx`
-	// file **after** the virtual machine is started. This is useful for setting
-	// advanced properties that are not supported by the plugin.
+	// file after the virtual machine build is complete. This is useful for
+	// setting advanced properties that are not supported by the plugin.
 	//
 	// ~> **Note**: This option is intended for advanced users who understand
 	// the ramifications of making changes to the `.vmx` file. This option is

--- a/docs-partials/builder/vmware/common/VMXConfig-not-required.mdx
+++ b/docs-partials/builder/vmware/common/VMXConfig-not-required.mdx
@@ -1,7 +1,7 @@
 <!-- Code generated from the comments of the VMXConfig struct in builder/vmware/common/vmx_config.go; DO NOT EDIT MANUALLY -->
 
 - `vmx_data` (map[string]string) - Key-value pairs that will be inserted into the virtual machine `.vmx`
-  file **before** the virtual machine is started. This is useful for
+  file before the virtual machine is started. This is useful for
   setting advanced properties that are not supported by the plugin.
   
   ~> **Note**: This option is intended for advanced users who understand
@@ -9,8 +9,8 @@
   not necessary for most users.
 
 - `vmx_data_post` (map[string]string) - Key-value pairs that will be inserted into the virtual machine `.vmx`
-  file **after** the virtual machine is started. This is useful for setting
-  advanced properties that are not supported by the plugin.
+  file after the virtual machine build is complete. This is useful for
+  setting advanced properties that are not supported by the plugin.
   
   ~> **Note**: This option is intended for advanced users who understand
   the ramifications of making changes to the `.vmx` file. This option is


### PR DESCRIPTION
### Description

Updated comments and documentation to specify that `vmx_data_post` is applied after the virtual machine build is complete, rather than after the virtual machine is started. This improves clarity for advanced users configuring VMX options.

Ran `make generate` to generate the documentation from the codebase.

### Reference

Ref: #400

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.

